### PR TITLE
AD.usablePeriod id element with [x], issue#12

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+*.xml text eol=crlf
+

--- a/resources/AD.xml
+++ b/resources/AD.xml
@@ -904,7 +904,7 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="AD.useablePeriod">
+    <element id="AD.useablePeriod[x]">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype">
         <valueString value="SXPR_TS"/>
       </extension>


### PR DESCRIPTION
- see issue https://github.com/HL7/cda-core-2.0/issues/12
- correction is in line 907:     <element id="AD.useablePeriod[x]"> , github pull requests shows that whole file is changed, there are crlf in the line endings, i added a .gitattributes together with this pull request, which already works locally with my changes, but the pull request doest not yet show hat effect, hopefully with the next pull request.
