### PR TITLE
update to R4, V3 ValueSet with terminology.hl7.org

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -10,10 +10,11 @@
     "specification": "http://build.fhir.org/"
   },
   "template" : "hl7.cda.template",
-  "version" : "3.0.1",
+  "version": "4.0.0",
   "fixed-business-version": "0.0.1",
   "license" : "CC0-1.0",
   "npm-name" : "hl7.fhir.cda",
+  "path-pattern": "[type]-[id].html",
   "canonicalBase": "http://hl7.org/fhir/cda",
   "source": "hl7.fhir.cda.xml",
   "sct-edition": "http://snomed.info/sct/731000124108",

--- a/resources/AD.xml
+++ b/resources/AD.xml
@@ -54,7 +54,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="AD.isNotOrdered">

--- a/resources/ANY.xml
+++ b/resources/ANY.xml
@@ -41,7 +41,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
   </differential>

--- a/resources/Act.xml
+++ b/resources/Act.xml
@@ -64,7 +64,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
     <element id="Act.negationInd">
@@ -93,7 +93,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActStatus"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActStatus"/>
       </binding>
     </element>
     <element id="Act.effectiveTime">
@@ -113,7 +113,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActPriority"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActPriority"/>
       </binding>
     </element>
     <element id="Act.languageCode">
@@ -125,7 +125,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-HumanLanguage"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-HumanLanguage"/>
       </binding>
     </element>
     <element id="Act.subject">
@@ -148,7 +148,7 @@
       <fixedCode value="SBJ"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetSubject"/>
       </binding>
     </element>
     <element id="Act.subject.contextControlCode">
@@ -163,7 +163,7 @@
       <fixedCode value="OP"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Act.subject.awarenessCode">
@@ -175,7 +175,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Act.subject.relatedSubject">
@@ -206,7 +206,7 @@
       <fixedCode value="SPC"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="Act.specimen.specimenRole">
@@ -237,7 +237,7 @@
       <fixedCode value="PRF"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationPhysicalPerformer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationPhysicalPerformer"/>
       </binding>
     </element>
     <element id="Act.performer.time">
@@ -257,7 +257,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationMode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationMode"/>
       </binding>
     </element>
     <element id="Act.performer.assignedEntity">
@@ -296,7 +296,7 @@
       <fixedCode value="INF"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationInformationGenerator"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationInformationGenerator"/>
       </binding>
     </element>
     <element id="Act.informant.contextControlCode">
@@ -311,7 +311,7 @@
       <fixedCode value="OP"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Act.informant.assignedEntity">
@@ -348,7 +348,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Act.participant.contextControlCode">
@@ -363,7 +363,7 @@
       <fixedCode value="OP"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Act.participant.time">
@@ -383,7 +383,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Act.participant.participantRole">
@@ -604,7 +604,7 @@
       <fixedCode value="PRCN"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActRelationshipConditional"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipConditional"/>
       </binding>
     </element>
     <element id="Act.precondition.criterion">

--- a/resources/AssignedAuthor.xml
+++ b/resources/AssignedAuthor.xml
@@ -40,7 +40,7 @@
       <fixedCode value="ASSIGNED"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassAssignedEntity"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassAssignedEntity"/>
       </binding>
     </element>
     <element id="AssignedAuthor.id">
@@ -60,7 +60,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleCode"/>
       </binding>
     </element>
     <element id="AssignedAuthor.addr">

--- a/resources/AssignedCustodian.xml
+++ b/resources/AssignedCustodian.xml
@@ -40,7 +40,7 @@
       <fixedCode value="ASSIGNED"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassAssignedEntity"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassAssignedEntity"/>
       </binding>
     </element>
     <element id="AssignedCustodian.representedCustodianOrganization">

--- a/resources/AssignedEntity.xml
+++ b/resources/AssignedEntity.xml
@@ -33,7 +33,7 @@
       <fixedCode value="ASSIGNED"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassAssignedEntity"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassAssignedEntity"/>
       </binding>
     </element>
     <element id="AssignedEntity.id">
@@ -53,7 +53,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleCode"/>
       </binding>
     </element>
     <element id="AssignedEntity.addr">

--- a/resources/AssociatedEntity.xml
+++ b/resources/AssociatedEntity.xml
@@ -38,7 +38,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassAssociative"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassAssociative"/>
       </binding>
     </element>
     <element id="AssociatedEntity.id">
@@ -58,7 +58,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleCode"/>
       </binding>
     </element>
     <element id="AssociatedEntity.addr">

--- a/resources/Authenticator.xml
+++ b/resources/Authenticator.xml
@@ -41,7 +41,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="Authenticator.typeCode">
@@ -56,7 +56,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Authenticator.realmCode">

--- a/resources/Author.xml
+++ b/resources/Author.xml
@@ -41,7 +41,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="Author.typeCode">
@@ -56,7 +56,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Author.contextControlCode">
@@ -71,7 +71,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Author.realmCode">

--- a/resources/AuthoringDevice.xml
+++ b/resources/AuthoringDevice.xml
@@ -34,7 +34,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassDevice"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassDevice"/>
       </binding>
     </element>
     <element id="AuthoringDevice.determinerCode">
@@ -50,7 +50,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminer"/>
       </binding>
     </element>
     <element id="AuthoringDevice.code">
@@ -62,7 +62,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityCode"/>
       </binding>
     </element>
     <element id="AuthoringDevice.manufacturerModelName">
@@ -74,7 +74,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ManufacturerModelName"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ManufacturerModelName"/>
       </binding>
     </element>
     <element id="AuthoringDevice.softwareName">
@@ -86,7 +86,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-SoftwareName"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-SoftwareName"/>
       </binding>
     </element>
     <element id="AuthoringDevice.asMaintainedEntity">

--- a/resources/Authorization.xml
+++ b/resources/Authorization.xml
@@ -39,7 +39,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="Authorization.typeCode">
@@ -53,7 +53,7 @@
       <fixedCode value="AUT"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Authorization.realmCode">

--- a/resources/Birthplace.xml
+++ b/resources/Birthplace.xml
@@ -41,7 +41,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassPassive"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassPassive"/>
       </binding>
     </element>
     <element id="Birthplace.place">

--- a/resources/ClinicalDocument.xml
+++ b/resources/ClinicalDocument.xml
@@ -44,7 +44,7 @@
       
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClass"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClass"/>
       </binding>
     </element>
     <element id="ClinicalDocument.moodCode">
@@ -60,7 +60,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="ClinicalDocument.id">
@@ -82,7 +82,7 @@
       
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-DocumentType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-DocumentType"/>
       </binding>
     </element>
     <element id="ClinicalDocument.title">
@@ -120,7 +120,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-HumanLanguage"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-HumanLanguage"/>
       </binding>
     </element>
     <element id="ClinicalDocument.setId">

--- a/resources/Component2.xml
+++ b/resources/Component2.xml
@@ -45,7 +45,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="Component2.typeCode">
@@ -59,7 +59,7 @@
       <fixedCode value="AUT"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Component2.contextConductionInd">

--- a/resources/ComponentOf.xml
+++ b/resources/ComponentOf.xml
@@ -39,7 +39,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="ComponentOf.typeCode">
@@ -53,7 +53,7 @@
       <fixedCode value="AUT"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="ComponentOf.realmCode">

--- a/resources/Consent.xml
+++ b/resources/Consent.xml
@@ -41,7 +41,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClass"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClass"/>
       </binding>
     </element>
     <element id="Consent.moodCode">
@@ -57,7 +57,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="Consent.id">
@@ -77,7 +77,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
     <element id="Consent.statusCode">
@@ -92,7 +92,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActStatus"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActStatus"/>
       </binding>
     </element>
   </differential>

--- a/resources/Criterion.xml
+++ b/resources/Criterion.xml
@@ -33,7 +33,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassObservation"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassObservation"/>
       </binding>
     </element>
     <element id="Criterion.moodCode">
@@ -49,7 +49,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMoodPredicate"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMoodPredicate"/>
       </binding>
     </element>
     <element id="Criterion.code">
@@ -61,7 +61,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
     <element id="Criterion.text">

--- a/resources/Custodian.xml
+++ b/resources/Custodian.xml
@@ -41,7 +41,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="Custodian.typeCode">
@@ -56,7 +56,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Custodian.realmCode">

--- a/resources/CustodianOrganization.xml
+++ b/resources/CustodianOrganization.xml
@@ -41,7 +41,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassOrganization"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassOrganization"/>
       </binding>
     </element>
     <element id="CustodianOrganization.determinerCode">
@@ -57,7 +57,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminer"/>
       </binding>
     </element>
     <element id="CustodianOrganization.id">

--- a/resources/DataEnterer.xml
+++ b/resources/DataEnterer.xml
@@ -40,7 +40,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="DataEnterer.typeCode">
@@ -55,7 +55,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="DataEnterer.contextControlCode">
@@ -70,7 +70,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="DataEnterer.realmCode">

--- a/resources/Device.xml
+++ b/resources/Device.xml
@@ -41,7 +41,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassDevice"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassDevice"/>
       </binding>
     </element>
     <element id="Device.determinerCode">
@@ -57,7 +57,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminer"/>
       </binding>
     </element>
     <element id="Device.code">
@@ -69,7 +69,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityCode"/>
       </binding>
     </element>
     <element id="Device.manufacturerModelName">
@@ -81,7 +81,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ManufacturerModelName"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ManufacturerModelName"/>
       </binding>
     </element>
     <element id="Device.softwareName">
@@ -93,7 +93,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-SoftwareName"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-SoftwareName"/>
       </binding>
     </element>
   </differential>

--- a/resources/DocumentationOf.xml
+++ b/resources/DocumentationOf.xml
@@ -40,7 +40,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="DocumentationOf.typeCode">
@@ -55,7 +55,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="DocumentationOf.realmCode">

--- a/resources/ED.xml
+++ b/resources/ED.xml
@@ -52,7 +52,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-CompressionAlgorithm"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-CompressionAlgorithm"/>
       </binding>
     </element>
     <element id="ED.integrityCheck">
@@ -78,7 +78,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-IntegrityCheckAlgorithm"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-IntegrityCheckAlgorithm"/>
       </binding>
     </element>
     <element id="ED.language">

--- a/resources/ENXP.xml
+++ b/resources/ENXP.xml
@@ -45,7 +45,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="ENXP.partType">
@@ -65,7 +65,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityNamePartType"/>
       </binding>
     </element>
     <element id="ENXP.qualifier">
@@ -85,7 +85,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNamePartQualifier"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityNamePartQualifier"/>
       </binding>
     </element>
     <element id="ENXP.value">

--- a/resources/EncompassingEncounter.xml
+++ b/resources/EncompassingEncounter.xml
@@ -43,7 +43,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClass"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClass"/>
       </binding>
     </element>
     <element id="EncompassingEncounter.moodCode">
@@ -59,7 +59,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="EncompassingEncounter.id">
@@ -79,7 +79,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActEncounterCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"/>
       </binding>
     </element>
     <element id="EncompassingEncounter.effectiveTime">
@@ -111,7 +111,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EncounterDischargeDisposition"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EncounterDischargeDisposition"/>
       </binding>
     </element>
     <element id="EncompassingEncounter.responsibleParty">
@@ -135,7 +135,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="EncompassingEncounter.responsibleParty.assignedEntity">
@@ -201,7 +201,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetLocation"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetLocation"/>
       </binding>
     </element>
     <element id="EncompassingEncounter.location.healthCareFacility">

--- a/resources/Encounter.xml
+++ b/resources/Encounter.xml
@@ -41,7 +41,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClass"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClass"/>
       </binding>
     </element>
     <element id="Encounter.moodCode">
@@ -71,7 +71,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActEncounterCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"/>
       </binding>
     </element>
     <element id="Encounter.text">
@@ -91,7 +91,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActStatus"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActStatus"/>
       </binding>
     </element>
     <element id="Encounter.effectiveTime">
@@ -111,7 +111,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActPriority"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActPriority"/>
       </binding>
     </element>
     <element id="Encounter.subject">
@@ -135,7 +135,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetSubject"/>
       </binding>
     </element>
     <element id="Encounter.subject.contextControlCode">
@@ -151,7 +151,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Encounter.subject.awarenessCode">
@@ -163,7 +163,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Encounter.subject.relatedSubject">
@@ -195,7 +195,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="Encounter.specimen.specimenRole">
@@ -227,7 +227,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationPhysicalPerformer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationPhysicalPerformer"/>
       </binding>
     </element>
     <element id="Encounter.performer.time">
@@ -247,7 +247,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationMode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationMode"/>
       </binding>
     </element>
     <element id="Encounter.performer.assignedEntity">
@@ -287,7 +287,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationInformationGenerator"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationInformationGenerator"/>
       </binding>
     </element>
     <element id="Encounter.informant.contextControlCode">
@@ -303,7 +303,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Encounter.informant.assignedEntity">
@@ -341,7 +341,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Encounter.participant.contextControlCode">
@@ -357,7 +357,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Encounter.participant.time">
@@ -377,7 +377,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Encounter.participant.participantRole">
@@ -602,7 +602,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActRelationshipConditional"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipConditional"/>
       </binding>
     </element>
     <element id="Encounter.precondition.criterion">

--- a/resources/Entity.xml
+++ b/resources/Entity.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassRoot"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassRoot"/>
       </binding>
     </element>
     <element id="Entity.determinerCode">
@@ -58,7 +58,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminer"/>
       </binding>
     </element>
     <element id="Entity.id">
@@ -78,7 +78,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityCode"/>
       </binding>
     </element>
     <element id="Entity.desc">

--- a/resources/ExternalAct.xml
+++ b/resources/ExternalAct.xml
@@ -40,7 +40,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClass"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClass"/>
       </binding>
     </element>
     <element id="ExternalAct.moodCode">
@@ -56,7 +56,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="ExternalAct.id">
@@ -76,7 +76,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
     <element id="ExternalAct.text">

--- a/resources/ExternalDocument.xml
+++ b/resources/ExternalDocument.xml
@@ -40,7 +40,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassDocument"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassDocument"/>
       </binding>
     </element>
     <element id="ExternalDocument.moodCode">
@@ -56,7 +56,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="ExternalDocument.id">
@@ -76,7 +76,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-DocumentType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-DocumentType"/>
       </binding>
     </element>
     <element id="ExternalDocument.text">

--- a/resources/ExternalObservation.xml
+++ b/resources/ExternalObservation.xml
@@ -40,7 +40,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassObservation"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassObservation"/>
       </binding>
     </element>
     <element id="ExternalObservation.moodCode">
@@ -56,7 +56,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="ExternalObservation.id">
@@ -76,7 +76,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
     <element id="ExternalObservation.text">

--- a/resources/ExternalProcedure.xml
+++ b/resources/ExternalProcedure.xml
@@ -41,7 +41,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassProcedure"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassProcedure"/>
       </binding>
     </element>
     <element id="ExternalProcedure.moodCode">
@@ -57,7 +57,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="ExternalProcedure.id">
@@ -77,7 +77,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
     <element id="ExternalProcedure.text">

--- a/resources/Guardian.xml
+++ b/resources/Guardian.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassAgent"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassAgent"/>
       </binding>
     </element>
     <element id="Guardian.id">
@@ -62,7 +62,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleCode"/>
       </binding>
     </element>
     <element id="Guardian.addr">

--- a/resources/HealthCareFacility.xml
+++ b/resources/HealthCareFacility.xml
@@ -32,7 +32,7 @@
       <defaultValueCode value="SDLOC"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassServiceDeliveryLocation"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassServiceDeliveryLocation"/>
       </binding>
     </element>
     <element id="HealthCareFacility.id">
@@ -52,7 +52,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ServiceDeliveryLocationRoleType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType"/>
       </binding>
     </element>
     <element id="HealthCareFacility.location">

--- a/resources/InFulfillmentOf.xml
+++ b/resources/InFulfillmentOf.xml
@@ -40,7 +40,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="InFulfillmentOf.typeCode">
@@ -55,7 +55,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="InFulfillmentOf.realmCode">

--- a/resources/Informant.xml
+++ b/resources/Informant.xml
@@ -40,7 +40,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="Informant.typeCode">
@@ -55,7 +55,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Informant.contextControlCode">
@@ -70,7 +70,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Informant.realmCode">

--- a/resources/InformationRecipient.xml
+++ b/resources/InformationRecipient.xml
@@ -42,7 +42,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="InformationRecipient.typeCode">
@@ -57,7 +57,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="InformationRecipient.realmCode">

--- a/resources/LabeledDrug.xml
+++ b/resources/LabeledDrug.xml
@@ -41,7 +41,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassManufacturedMaterial"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassManufacturedMaterial"/>
       </binding>
     </element>
     <element id="LabeledDrug.determinerCode">
@@ -57,7 +57,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminerDetermined"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminerDetermined"/>
       </binding>
     </element>
     <element id="LabeledDrug.code">
@@ -69,7 +69,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-DrugEntity"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-DrugEntity"/>
       </binding>
     </element>
     <element id="LabeledDrug.name">

--- a/resources/LanguageCommunication.xml
+++ b/resources/LanguageCommunication.xml
@@ -39,7 +39,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-HumanLanguage"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-HumanLanguage"/>
       </binding>
     </element>
     <element id="LanguageCommunication.modeCode">
@@ -51,7 +51,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-LanguageAbilityMode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-LanguageAbilityMode"/>
       </binding>
     </element>
     <element id="LanguageCommunication.proficiencyLevelCode">
@@ -63,7 +63,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-LanguageAbilityProficiency"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-LanguageAbilityProficiency"/>
       </binding>
     </element>
     <element id="LanguageCommunication.preferenceInd">

--- a/resources/LegalAuthenticator.xml
+++ b/resources/LegalAuthenticator.xml
@@ -42,7 +42,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="LegalAuthenticator.typeCode">
@@ -57,7 +57,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="LegalAuthenticator.contextControlCode">
@@ -72,7 +72,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="LegalAuthenticator.realmCode">

--- a/resources/MaintainedEntity.xml
+++ b/resources/MaintainedEntity.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassPassive"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassPassive"/>
       </binding>
     </element>
     <element id="MaintainedEntity.effectiveTime">

--- a/resources/ManufacturedProduct.xml
+++ b/resources/ManufacturedProduct.xml
@@ -34,7 +34,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassManufacturedProduct"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassManufacturedProduct"/>
       </binding>
     </element>
     <element id="ManufacturedProduct.id">

--- a/resources/Material.xml
+++ b/resources/Material.xml
@@ -44,7 +44,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassManufacturedMaterial"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassManufacturedMaterial"/>
       </binding>
     </element>
     <element id="Material.determinerCode">
@@ -60,7 +60,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminerDetermined"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminerDetermined"/>
       </binding>
     </element>
     <element id="Material.code">
@@ -72,7 +72,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-MaterialEntityClassType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-MaterialEntityClassType"/>
       </binding>
     </element>
     <element id="Material.name">

--- a/resources/NonXMLBody.xml
+++ b/resources/NonXMLBody.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassOrganizer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassOrganizer"/>
       </binding>
     </element>
     <element id="NonXMLBody.moodCode">
@@ -58,7 +58,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="NonXMLBody.text">
@@ -86,7 +86,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-HumanLanguage"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-HumanLanguage"/>
       </binding>
     </element>
   </differential>

--- a/resources/ON.xml
+++ b/resources/ON.xml
@@ -36,7 +36,7 @@
       <path value="ON.use"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-OrganizationNameUse"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-OrganizationNameUse"/>
       </binding>
     </element>
     <element id="ON.family">

--- a/resources/Observation.xml
+++ b/resources/Observation.xml
@@ -40,7 +40,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassObservation"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassObservation"/>
       </binding>
     </element>
     <element id="Observation.moodCode">
@@ -71,7 +71,7 @@
       
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ObservationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ObservationType"/>
       </binding>
     </element>
     <element id="Observation.negationInd">
@@ -108,7 +108,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActStatus"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActStatus"/>
       </binding>
     </element>
     <element id="Observation.effectiveTime">
@@ -128,7 +128,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActPriority"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActPriority"/>
       </binding>
     </element>
     <element id="Observation.repeatNumber">
@@ -148,7 +148,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-HumanLanguage"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-HumanLanguage"/>
       </binding>
     </element>
     <element id="Observation.value">
@@ -229,7 +229,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ObservationInterpretation"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ObservationInterpretation"/>
       </binding>
     </element>
     <element id="Observation.methodCode">
@@ -241,7 +241,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ObservationMethod"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ObservationMethod"/>
       </binding>
     </element>
     <element id="Observation.targetSiteCode">
@@ -274,7 +274,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActRelationshipPertains"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipPertains"/>
       </binding>
     </element>
     <element id="Observation.referenceRange.observationRange">
@@ -306,7 +306,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetSubject"/>
       </binding>
     </element>
     <element id="Observation.subject.contextControlCode">
@@ -322,7 +322,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Observation.subject.awarenessCode">
@@ -334,7 +334,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Observation.subject.relatedSubject">
@@ -366,7 +366,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="Observation.specimen.specimenRole">
@@ -398,7 +398,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationPhysicalPerformer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationPhysicalPerformer"/>
       </binding>
     </element>
     <element id="Observation.performer.time">
@@ -418,7 +418,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationMode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationMode"/>
       </binding>
     </element>
     <element id="Observation.performer.assignedEntity">
@@ -458,7 +458,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationInformationGenerator"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationInformationGenerator"/>
       </binding>
     </element>
     <element id="Observation.informant.contextControlCode">
@@ -474,7 +474,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Observation.informant.assignedEntity">
@@ -512,7 +512,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Observation.participant.contextControlCode">
@@ -528,7 +528,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Observation.participant.time">
@@ -548,7 +548,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Observation.participant.participantRole">
@@ -773,7 +773,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActRelationshipConditional"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipConditional"/>
       </binding>
     </element>
     <element id="Observation.precondition.criterion">

--- a/resources/ObservationMedia.xml
+++ b/resources/ObservationMedia.xml
@@ -43,7 +43,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassObservation"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassObservation"/>
       </binding>
     </element>
     <element id="ObservationMedia.moodCode">
@@ -59,7 +59,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="ObservationMedia.id">
@@ -79,7 +79,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-HumanLanguage"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-HumanLanguage"/>
       </binding>
     </element>
     <element id="ObservationMedia.value">
@@ -112,7 +112,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetSubject"/>
       </binding>
     </element>
     <element id="ObservationMedia.subject.contextControlCode">
@@ -128,7 +128,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="ObservationMedia.subject.awarenessCode">
@@ -140,7 +140,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="ObservationMedia.subject.relatedSubject">
@@ -172,7 +172,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="ObservationMedia.specimen.specimenRole">
@@ -204,7 +204,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationPhysicalPerformer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationPhysicalPerformer"/>
       </binding>
     </element>
     <element id="ObservationMedia.performer.time">
@@ -224,7 +224,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationMode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationMode"/>
       </binding>
     </element>
     <element id="ObservationMedia.performer.assignedEntity">
@@ -264,7 +264,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationInformationGenerator"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationInformationGenerator"/>
       </binding>
     </element>
     <element id="ObservationMedia.informant.contextControlCode">
@@ -280,7 +280,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="ObservationMedia.informant.assignedEntity">
@@ -318,7 +318,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="ObservationMedia.participant.contextControlCode">
@@ -334,7 +334,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="ObservationMedia.participant.time">
@@ -354,7 +354,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="ObservationMedia.participant.participantRole">
@@ -579,7 +579,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActRelationshipConditional"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipConditional"/>
       </binding>
     </element>
     <element id="ObservationMedia.precondition.criterion">

--- a/resources/ObservationRange.xml
+++ b/resources/ObservationRange.xml
@@ -33,7 +33,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassObservation"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassObservation"/>
       </binding>
     </element>
     <element id="ObservationRange.moodCode">
@@ -49,7 +49,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMoodPredicate"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMoodPredicate"/>
       </binding>
     </element>
     <element id="ObservationRange.code">
@@ -61,7 +61,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
     <element id="ObservationRange.text">
@@ -150,7 +150,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ObservationInterpretation"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ObservationInterpretation"/>
       </binding>
     </element>
   </differential>

--- a/resources/Order.xml
+++ b/resources/Order.xml
@@ -40,7 +40,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClass"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClass"/>
       </binding>
     </element>
     <element id="Order.moodCode">
@@ -56,7 +56,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMoodIntent"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMoodIntent"/>
       </binding>
     </element>
     <element id="Order.id">
@@ -77,7 +77,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
     <element id="Order.priorityCode">
@@ -89,7 +89,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActPriority"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActPriority"/>
       </binding>
     </element>
   </differential>

--- a/resources/Organization.xml
+++ b/resources/Organization.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassOrganization"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassOrganization"/>
       </binding>
     </element>
     <element id="Organization.determinerCode">
@@ -58,7 +58,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminer"/>
       </binding>
     </element>
     <element id="Organization.id">
@@ -102,7 +102,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-OrganizationIndustryClass"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-OrganizationIndustryClass"/>
       </binding>
     </element>
     <element id="Organization.asOrganizationPartOf">

--- a/resources/OrganizationPartOf.xml
+++ b/resources/OrganizationPartOf.xml
@@ -34,7 +34,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassPartitive"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassPartitive"/>
       </binding>
     </element>
     <element id="OrganizationPartOf.id">
@@ -55,7 +55,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleCode"/>
       </binding>
     </element>
     <element id="OrganizationPartOf.statusCode">

--- a/resources/Organizer.xml
+++ b/resources/Organizer.xml
@@ -52,7 +52,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="Organizer.id">
@@ -72,7 +72,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
     <element id="Organizer.statusCode">
@@ -85,7 +85,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActStatus"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActStatus"/>
       </binding>
     </element>
     <element id="Organizer.effectiveTime">
@@ -236,7 +236,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetSubject"/>
       </binding>
     </element>
     <element id="Organizer.subject.contextControlCode">
@@ -252,7 +252,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Organizer.subject.awarenessCode">
@@ -264,7 +264,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Organizer.subject.relatedSubject">
@@ -296,7 +296,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="Organizer.specimen.specimenRole">
@@ -328,7 +328,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationPhysicalPerformer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationPhysicalPerformer"/>
       </binding>
     </element>
     <element id="Organizer.performer.time">
@@ -348,7 +348,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationMode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationMode"/>
       </binding>
     </element>
     <element id="Organizer.performer.assignedEntity">
@@ -388,7 +388,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationInformationGenerator"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationInformationGenerator"/>
       </binding>
     </element>
     <element id="Organizer.informant.contextControlCode">
@@ -404,7 +404,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Organizer.informant.assignedEntity">
@@ -442,7 +442,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Organizer.participant.contextControlCode">
@@ -458,7 +458,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Organizer.participant.time">
@@ -478,7 +478,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Organizer.participant.participantRole">
@@ -703,7 +703,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActRelationshipConditional"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipConditional"/>
       </binding>
     </element>
     <element id="Organizer.precondition.criterion">

--- a/resources/PN.xml
+++ b/resources/PN.xml
@@ -36,7 +36,7 @@
       <path value="PN.use"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-PersonNameUse"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-PersonNameUse"/>
       </binding>
     </element>
   </differential>

--- a/resources/ParentDocument.xml
+++ b/resources/ParentDocument.xml
@@ -41,7 +41,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassClinicalDocument"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassClinicalDocument"/>
       </binding>
     </element>
     <element id="ParentDocument.moodCode">
@@ -57,7 +57,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="ParentDocument.id">
@@ -78,7 +78,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-DocumentType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-DocumentType"/>
       </binding>
     </element>
     <element id="ParentDocument.text">

--- a/resources/Participant.xml
+++ b/resources/Participant.xml
@@ -40,7 +40,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="Participant.typeCode">
@@ -54,7 +54,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Participant.contextControlCode">
@@ -69,7 +69,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Participant.realmCode">

--- a/resources/ParticipantRole.xml
+++ b/resources/ParticipantRole.xml
@@ -33,7 +33,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassRoot"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassRoot"/>
       </binding>
     </element>
     <element id="ParticipantRole.id">
@@ -53,7 +53,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleCode"/>
       </binding>
     </element>
     <element id="ParticipantRole.addr">

--- a/resources/Patient.xml
+++ b/resources/Patient.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassLivingSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassLivingSubject"/>
       </binding>
     </element>
     <element id="Patient.determinerCode">
@@ -58,7 +58,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminer"/>
       </binding>
     </element>
     <element id="Patient.id">
@@ -97,7 +97,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-AdministrativeGender"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-AdministrativeGender"/>
       </binding>
     </element>
     <element id="Patient.birthTime">
@@ -139,7 +139,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-MaritalStatus"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-MaritalStatus"/>
       </binding>
     </element>
     <element id="Patient.religiousAffiliationCode">
@@ -151,7 +151,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ReligiousAffiliation"/>
       </binding>
     </element>
     <element id="Patient.raceCode">
@@ -163,7 +163,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-Race"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-Race"/>
       </binding>
     </element>
     <element id="Patient.ethnicGroupCode">
@@ -175,7 +175,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-Ethnicity"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-Ethnicity"/>
       </binding>
     </element>
     <element id="Patient.guardian">

--- a/resources/PatientRole.xml
+++ b/resources/PatientRole.xml
@@ -41,7 +41,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassRelationshipFormal"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassRelationshipFormal"/>
       </binding>
     </element>
     <element id="PatientRole.id">

--- a/resources/Person.xml
+++ b/resources/Person.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassLivingSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassLivingSubject"/>
       </binding>
     </element>
     <element id="Person.determinerCode">
@@ -58,7 +58,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminer"/>
       </binding>
     </element>
     <element id="Person.name">

--- a/resources/Place.xml
+++ b/resources/Place.xml
@@ -43,7 +43,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassPlace"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassPlace"/>
       </binding>
     </element>
     <element id="Place.determinerCode">
@@ -59,7 +59,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminer"/>
       </binding>
     </element>
     <element id="Place.name">

--- a/resources/PlayingEntity.xml
+++ b/resources/PlayingEntity.xml
@@ -33,7 +33,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassRoot"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassRoot"/>
       </binding>
     </element>
     <element id="PlayingEntity.determinerCode">
@@ -49,7 +49,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminer"/>
       </binding>
     </element>
     <element id="PlayingEntity.code">
@@ -61,7 +61,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityCode"/>
       </binding>
     </element>
     <element id="PlayingEntity.quantity">

--- a/resources/Procedure.xml
+++ b/resources/Procedure.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassProcedure"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassProcedure"/>
       </binding>
     </element>
     <element id="Procedure.moodCode">
@@ -98,7 +98,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActStatus"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActStatus"/>
       </binding>
     </element>
     <element id="Procedure.effectiveTime">
@@ -118,7 +118,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActPriority"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActPriority"/>
       </binding>
     </element>
     <element id="Procedure.languageCode">
@@ -130,7 +130,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-HumanLanguage"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-HumanLanguage"/>
       </binding>
     </element>
     <element id="Procedure.methodCode">
@@ -181,7 +181,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetSubject"/>
       </binding>
     </element>
     <element id="Procedure.subject.contextControlCode">
@@ -197,7 +197,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Procedure.subject.awarenessCode">
@@ -209,7 +209,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Procedure.subject.relatedSubject">
@@ -241,7 +241,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="Procedure.specimen.specimenRole">
@@ -273,7 +273,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationPhysicalPerformer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationPhysicalPerformer"/>
       </binding>
     </element>
     <element id="Procedure.performer.time">
@@ -293,7 +293,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationMode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationMode"/>
       </binding>
     </element>
     <element id="Procedure.performer.assignedEntity">
@@ -333,7 +333,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationInformationGenerator"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationInformationGenerator"/>
       </binding>
     </element>
     <element id="Procedure.informant.contextControlCode">
@@ -349,7 +349,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Procedure.informant.assignedEntity">
@@ -387,7 +387,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Procedure.participant.contextControlCode">
@@ -403,7 +403,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Procedure.participant.time">
@@ -423,7 +423,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Procedure.participant.participantRole">
@@ -648,7 +648,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActRelationshipConditional"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipConditional"/>
       </binding>
     </element>
     <element id="Procedure.precondition.criterion">

--- a/resources/RecordTarget.xml
+++ b/resources/RecordTarget.xml
@@ -44,7 +44,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="RecordTarget.typeCode">
@@ -59,7 +59,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="RecordTarget.contextControlCode">
@@ -74,7 +74,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="RecordTarget.realmCode">

--- a/resources/RegionOfInterest.xml
+++ b/resources/RegionOfInterest.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassROI"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassROI"/>
       </binding>
     </element>
     <element id="RegionOfInterest.moodCode">
@@ -58,7 +58,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="RegionOfInterest.id">
@@ -109,7 +109,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetSubject"/>
       </binding>
     </element>
     <element id="RegionOfInterest.subject.contextControlCode">
@@ -125,7 +125,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="RegionOfInterest.subject.awarenessCode">
@@ -137,7 +137,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="RegionOfInterest.subject.relatedSubject">
@@ -169,7 +169,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="RegionOfInterest.specimen.specimenRole">
@@ -201,7 +201,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationPhysicalPerformer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationPhysicalPerformer"/>
       </binding>
     </element>
     <element id="RegionOfInterest.performer.time">
@@ -221,7 +221,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationMode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationMode"/>
       </binding>
     </element>
     <element id="RegionOfInterest.performer.assignedEntity">
@@ -261,7 +261,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationInformationGenerator"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationInformationGenerator"/>
       </binding>
     </element>
     <element id="RegionOfInterest.informant.contextControlCode">
@@ -277,7 +277,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="RegionOfInterest.informant.assignedEntity">
@@ -315,7 +315,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="RegionOfInterest.participant.contextControlCode">
@@ -331,7 +331,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="RegionOfInterest.participant.time">
@@ -351,7 +351,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="RegionOfInterest.participant.participantRole">
@@ -576,7 +576,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActRelationshipConditional"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipConditional"/>
       </binding>
     </element>
     <element id="RegionOfInterest.precondition.criterion">

--- a/resources/RelatedDocument.xml
+++ b/resources/RelatedDocument.xml
@@ -40,7 +40,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-NullFlavor"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
       </binding>
     </element>
     <element id="RelatedDocument.typeCode">
@@ -54,7 +54,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="RelatedDocument.realmCode">

--- a/resources/RelatedEntity.xml
+++ b/resources/RelatedEntity.xml
@@ -39,7 +39,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassMutualRelationship"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassMutualRelationship"/>
       </binding>
     </element>
     <element id="RelatedEntity.code">
@@ -51,7 +51,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-PersonalRelationshipRoleType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-PersonalRelationshipRoleType"/>
       </binding>
     </element>
     <element id="RelatedEntity.addr">

--- a/resources/RelatedSubject.xml
+++ b/resources/RelatedSubject.xml
@@ -48,7 +48,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-PersonalRelationshipRoleType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-PersonalRelationshipRoleType"/>
       </binding>
     </element>
     <element id="RelatedSubject.addr">

--- a/resources/ST.xml
+++ b/resources/ST.xml
@@ -52,7 +52,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-CompressionAlgorithm"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-CompressionAlgorithm"/>
       </binding>
     </element>
     <element id="ST.integrityCheck">
@@ -78,7 +78,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-IntegrityCheckAlgorithm"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-IntegrityCheckAlgorithm"/>
       </binding>
     </element>
     <element id="ST.language">

--- a/resources/Section.xml
+++ b/resources/Section.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassOrganizer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassOrganizer"/>
       </binding>
     </element>
     <element id="Section.moodCode">
@@ -58,7 +58,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="Section.id">
@@ -78,7 +78,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-DocumentSectionType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-DocumentSectionType"/>
       </binding>
     </element>
     <element id="Section.title">
@@ -116,7 +116,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-HumanLanguage"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-HumanLanguage"/>
       </binding>
     </element>
     <element id="Section.subject">
@@ -140,7 +140,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetSubject"/>
       </binding>
     </element>
     <element id="Section.subject.contextControlCode">
@@ -156,7 +156,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Section.subject.awarenessCode">
@@ -168,7 +168,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Section.subject.relatedSubject">
@@ -208,7 +208,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationInformationGenerator"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationInformationGenerator"/>
       </binding>
     </element>
     <element id="Section.informant.contextControlCode">
@@ -224,7 +224,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Section.informant.assignedEntity">

--- a/resources/ServiceEvent.xml
+++ b/resources/ServiceEvent.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClass"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClass"/>
       </binding>
     </element>
     <element id="ServiceEvent.moodCode">
@@ -58,7 +58,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="ServiceEvent.id">
@@ -113,7 +113,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationFunction"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationFunction"/>
       </binding>
     </element>
     <element id="ServiceEvent.performer.time">

--- a/resources/SpecimenRole.xml
+++ b/resources/SpecimenRole.xml
@@ -34,7 +34,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RoleClassSpecimen"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleClassSpecimen"/>
       </binding>
     </element>
     <element id="SpecimenRole.id">

--- a/resources/StructuredBody.xml
+++ b/resources/StructuredBody.xml
@@ -42,7 +42,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassOrganizer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassOrganizer"/>
       </binding>
     </element>
     <element id="StructuredBody.moodCode">
@@ -58,7 +58,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActMood"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMood"/>
       </binding>
     </element>
     <element id="StructuredBody.confidentialityCode">
@@ -78,7 +78,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-HumanLanguage"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-HumanLanguage"/>
       </binding>
     </element>
     <element id="StructuredBody.component">

--- a/resources/SubjectPerson.xml
+++ b/resources/SubjectPerson.xml
@@ -41,7 +41,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityClassLivingSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassLivingSubject"/>
       </binding>
     </element>
     <element id="SubjectPerson.determinerCode">
@@ -57,7 +57,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityDeterminer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminer"/>
       </binding>
     </element>
     <element id="SubjectPerson.name">
@@ -88,7 +88,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-AdministrativeGender"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-AdministrativeGender"/>
       </binding>
     </element>
     <element id="SubjectPerson.birthTime">

--- a/resources/SubstanceAdministration.xml
+++ b/resources/SubstanceAdministration.xml
@@ -44,7 +44,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClass"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClass"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.moodCode">
@@ -74,7 +74,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-SubstanceAdministrationActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-SubstanceAdministrationActCode"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.negationInd">
@@ -103,7 +103,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActStatus"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActStatus"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.effectiveTime">
@@ -136,7 +136,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActPriority"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActPriority"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.repeatNumber">
@@ -156,7 +156,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-RouteOfAdministration"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-RouteOfAdministration"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.approachSiteCode">
@@ -168,7 +168,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActSite"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActSite"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.doseQuantity">
@@ -204,7 +204,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-AdministrableDrugForm"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-AdministrableDrugForm"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.consumable">
@@ -228,7 +228,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.consumable.manufacturedProduct">
@@ -260,7 +260,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetSubject"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.subject.contextControlCode">
@@ -276,7 +276,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.subject.awarenessCode">
@@ -288,7 +288,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.subject.relatedSubject">
@@ -320,7 +320,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.specimen.specimenRole">
@@ -352,7 +352,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationPhysicalPerformer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationPhysicalPerformer"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.performer.time">
@@ -372,7 +372,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationMode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationMode"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.performer.assignedEntity">
@@ -412,7 +412,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationInformationGenerator"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationInformationGenerator"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.informant.contextControlCode">
@@ -428,7 +428,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.informant.assignedEntity">
@@ -466,7 +466,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.participant.contextControlCode">
@@ -482,7 +482,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.participant.time">
@@ -502,7 +502,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.participant.participantRole">
@@ -727,7 +727,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActRelationshipConditional"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipConditional"/>
       </binding>
     </element>
     <element id="SubstanceAdministration.precondition.criterion">

--- a/resources/Supply.xml
+++ b/resources/Supply.xml
@@ -43,7 +43,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActClassSupply"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassSupply"/>
       </binding>
     </element>
     <element id="Supply.moodCode">
@@ -73,7 +73,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActCode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
     <element id="Supply.text">
@@ -93,7 +93,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActStatus"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActStatus"/>
       </binding>
     </element>
     <element id="Supply.effectiveTime">
@@ -126,7 +126,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActPriority"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActPriority"/>
       </binding>
     </element>
     <element id="Supply.repeatNumber">
@@ -183,7 +183,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="Supply.product.manufacturedProduct">
@@ -216,7 +216,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetSubject"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetSubject"/>
       </binding>
     </element>
     <element id="Supply.subject.contextControlCode">
@@ -232,7 +232,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Supply.subject.awarenessCode">
@@ -244,7 +244,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Supply.subject.relatedSubject">
@@ -276,7 +276,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationTargetDirect"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationTargetDirect"/>
       </binding>
     </element>
     <element id="Supply.specimen.specimenRole">
@@ -308,7 +308,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationPhysicalPerformer"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationPhysicalPerformer"/>
       </binding>
     </element>
     <element id="Supply.performer.time">
@@ -328,7 +328,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationMode"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationMode"/>
       </binding>
     </element>
     <element id="Supply.performer.assignedEntity">
@@ -368,7 +368,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationInformationGenerator"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationInformationGenerator"/>
       </binding>
     </element>
     <element id="Supply.informant.contextControlCode">
@@ -384,7 +384,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Supply.informant.assignedEntity">
@@ -422,7 +422,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
     </element>
     <element id="Supply.participant.contextControlCode">
@@ -438,7 +438,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ContextControl"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
     </element>
     <element id="Supply.participant.time">
@@ -458,7 +458,7 @@
       </type>
       <binding>
         <strength value="extensible"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-TargetAwareness"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-TargetAwareness"/>
       </binding>
     </element>
     <element id="Supply.participant.participantRole">
@@ -683,7 +683,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-ActRelationshipConditional"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipConditional"/>
       </binding>
     </element>
     <element id="Supply.precondition.criterion">

--- a/resources/TEL.xml
+++ b/resources/TEL.xml
@@ -72,7 +72,7 @@
       </type>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-AddressUse"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-AddressUse"/>
       </binding>
     </element>
   </differential>

--- a/resources/TN.xml
+++ b/resources/TN.xml
@@ -61,7 +61,7 @@
       <path value="TN.use"/>
       <binding>
         <strength value="required"/>
-        <valueSetUri value="http://hl7.org/fhir/ValueSet/v3-EntityNameUse"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityNameUse"/>
       </binding>
     </element>
   </differential>


### PR DESCRIPTION
Please find attached the pull requests to update the current cda-core-2.0 from stu3 to R4. There were only two changes made:
- replace all occurrences of <ValueSetUri value= to <ValueSet value= (change of stu3 to R4) in the binding element
- replace all v3 ValueSets with http://hl7.org/fhir/ValueSet/v3-xyz to http://terminology.hl7.org/ValueSet/v3-xyz

With these two changes the ig publisher errors drop as following:

STU3: Errors: 174  Warnings: 206  Info: 0 (01:03.0351)
R4: Errors: 30  Warnings: 410  Info: 0 (01:26.0583)