### PR TITLE
xhtml instead missing StrucDoc.Text

### DIFF
--- a/resources/Section.xml
+++ b/resources/Section.xml
@@ -95,9 +95,9 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/StrucDoc.Text"/>
+        <code value="xhtml"/>
       </type>
-      
+      <mustSupport value="true"/>
     </element>
     <element id="Section.confidentialityCode">
       <path value="Section.confidentialityCode"/>


### PR DESCRIPTION
error message in qa.html: http://hl7.org/fhir/cda/StructureDefinition/StrucDoc.Text' does not resolve in current ig. 

Fixed this with adding xhtml as a type for the section. The Section.text has a representation of cdaText which is a marker to do the cda narrative to xhtml conversion.