### PR TITLE
adding RTO_PQ_PQ for Observation.value

### DIFF
--- a/resources/Observation.xml
+++ b/resources/Observation.xml
@@ -219,6 +219,9 @@
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
       </type>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/RTO_PQ_PQ"/>
+      </type>
     </element>
     <element id="Observation.interpretationCode">
       <path value="Observation.interpretationCode"/>


### PR DESCRIPTION
The cda sample file in cda-core-2.0 has an observation value with xsi:type RTO_PQ_PQ.
This pull requests adds the type RTO_PQ_PQ to observation.value which is an allowed type in a observation (hl7:ANY).

