### PR TITLE
v3 string datatypes enhancements

### DIFF
--- a/resources/AD.xml
+++ b/resources/AD.xml
@@ -90,7 +90,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.delimiter.partType">
@@ -120,7 +120,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.country.partType">
@@ -150,7 +150,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.state.partType">
@@ -180,7 +180,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.county.partType">
@@ -210,7 +210,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.city.partType">
@@ -240,7 +240,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.postalCode.partType">
@@ -270,7 +270,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.streetAddressLine.partType">
@@ -300,7 +300,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.houseNumber.partType">
@@ -330,7 +330,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.houseNumberNumeric.partType">
@@ -360,7 +360,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.direction.partType">
@@ -390,7 +390,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.streetName.partType">
@@ -420,7 +420,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.streetNameBase.partType">
@@ -450,7 +450,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.streetNameType.partType">
@@ -480,7 +480,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.additionalLocator.partType">
@@ -510,7 +510,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.unitID.partType">
@@ -540,7 +540,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.unitType.partType">
@@ -570,7 +570,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.careOf.partType">
@@ -600,7 +600,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.censusTract.partType">
@@ -630,7 +630,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.deliveryAddressLine.partType">
@@ -660,7 +660,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.deliveryInstallationType.partType">
@@ -690,7 +690,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.deliveryInstallationArea.partType">
@@ -720,7 +720,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.deliveryInstallationQualifier.partType">
@@ -750,7 +750,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.deliveryMode.partType">
@@ -780,7 +780,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.deliveryModeIdentifier.partType">
@@ -810,7 +810,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.buildingNumberSuffix.partType">
@@ -840,7 +840,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.postBox.partType">
@@ -870,7 +870,7 @@
         <max value="*"/>
       </base>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
       </type>
     </element>
     <element id="AD.precinct.partType">

--- a/resources/ADXP.xml
+++ b/resources/ADXP.xml
@@ -1,0 +1,42 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ADXP"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>A character string that may have a type-tag signifying its role in the address. Typical parts that exist in about every address are street, house number, or post box, postal code, city, country but other roles may be defined regionally, nationally, or on an enterprise level (e.g. in military addresses). Addresses are usually broken up into lines, which are indicated by special line-breaking delimiter elements (e.g., DEL).</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/ADXP"/>
+  <name value="ADXP"/>
+  <title value="ADXP: CharacterString (V3 Data Type)"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="A character string that may have a type-tag signifying its role in the address. Typical parts that exist in about every address are street, house number, or post box, postal code, city, country but other roles may be defined regionally, nationally, or on an enterprise level (e.g. in military addresses). Addresses are usually broken up into lines, which are indicated by special line-breaking delimiter elements (e.g., DEL)."/>
+  <kind value="logical"/>
+  <abstract value="false"/>
+  <type value="ADXP"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+  <derivation value="specialization"/>
+  <differential>
+    <element id="ADXP">
+      <path value="ADXP"/>
+      <definition value="A character string that may have a type-tag signifying its role in the address. Typical parts that exist in about every address are street, house number, or post box, postal code, city, country but other roles may be defined regionally, nationally, or on an enterprise level (e.g. in military addresses). Addresses are usually broken up into lines, which are indicated by special line-breaking delimiter elements (e.g., DEL)."/>
+      <min value="1"/>
+      <max value="*"/>
+    </element>
+    <element id="ADXP.partType">
+      <path value="ADXP.partType"/>
+      <representation value="xmlAttr"/>
+      <definition value="Specifies the type of the address part"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/ENXP.xml
+++ b/resources/ENXP.xml
@@ -28,26 +28,6 @@
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ENXP.nullFlavor">
-      <path value="ENXP.nullFlavor"/>
-      <representation value="xmlAttr"/>
-      <label value="Exceptional Value Detail"/>
-      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ANY.nullFlavor"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="code"/>
-      </type>
-      <binding>
-        <strength value="required"/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
-      </binding>
-    </element>
     <element id="ENXP.partType">
       <path value="ENXP.partType"/>
       <representation value="xmlAttr"/>
@@ -55,11 +35,6 @@
       <definition value="Indicates whether the name part is a given name, family name, prefix, suffix, etc."/>
       <min value="0"/>
       <max value="1"/>
-      <base>
-        <path value="ENXP.partType"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
       <type>
         <code value="code"/>
       </type>
@@ -75,11 +50,6 @@
       <definition value="qualifier is a set of codes each of which specifies a certain subcategory of the name part in addition to the main name part type. For example, a given name may be flagged as a nickname, a family name may be a pseudonym or a name of public records."/>
       <min value="0"/>
       <max value="*"/>
-      <base>
-        <path value="ENXP.qualifier"/>
-        <min value="0"/>
-        <max value="*"/>
-      </base>
       <type>
         <code value="code"/>
       </type>
@@ -87,15 +57,6 @@
         <strength value="required"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityNamePartQualifier"/>
       </binding>
-    </element>
-    <element id="ENXP.value">
-      <path value="ENXP.value"/>
-      <representation value="xmlText"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
     </element>
   </differential>
 </StructureDefinition>

--- a/resources/ST.xml
+++ b/resources/ST.xml
@@ -19,81 +19,42 @@
   <description value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="ST"/>
+  <type value="ED"/>
   <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-  <derivation value="specialization"/>
+  <derivation value="constraint"/>
   <differential>
-    <element id="ST">
-      <path value="ST"/>
+    <element id="ED">
+      <path value="ED"/>
       <definition value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ST.charset">
-      <path value="ST.charset"/>
-      <representation value="xmlAttr"/>
-      <label value="Charset"/>
-      <definition value="For character-based encoding types, this property specifies the character set and character encoding used. The charset shall be identified by an Internet Assigned Numbers Authority (IANA) Charset Registration [] in accordance with RFC 2978 []."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="ST.compression">
-      <path value="ST.compression"/>
+    <element id="ED.compression">
+      <path value="ED.compression"/>
       <representation value="xmlAttr"/>
       <label value="Compression"/>
       <definition value="Indicates whether the raw byte data is compressed, and what compression algorithm was used."/>
       <min value="0"/>
       <max value="0"/>
-      <type>
-        <code value="code"/>
-      </type>
-      <binding>
-        <strength value="required"/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-CompressionAlgorithm"/>
-      </binding>
     </element>
-    <element id="ST.integrityCheck">
-      <path value="ST.integrityCheck"/>
+    <element id="ED.integrityCheck">
+      <path value="ED.integrityCheck"/>
       <representation value="xmlAttr"/>
       <label value="Integrity Check"/>
       <definition value="The integrity check is a short binary value representing a cryptographically strong checksum that is calculated over the binary data. The purpose of this property, when communicated with a reference is for anyone to validate later whether the reference still resolved to the same data that the reference resolved to when the encapsulated data value with reference was created."/>
       <min value="0"/>
       <max value="0"/>
-      <type>
-        <code value="base64Binary"/>
-      </type>
     </element>
-    <element id="ST.integrityCheckAlgorithm">
-      <path value="ST.integrityCheckAlgorithm"/>
+    <element id="ED.integrityCheckAlgorithm">
+      <path value="ED.integrityCheckAlgorithm"/>
       <representation value="xmlAttr"/>
       <label value="Integrity Check Algorithm"/>
       <definition value="Specifies the algorithm used to compute the integrityCheck value. The cryptographically strong checksum algorithm Secure Hash Algorithm-1 (SHA-1) is currently the industry standard. It has superseded the MD5 algorithm only a couple of years ago, when certain flaws in the security of MD5 were discovered. Currently the SHA-1 hash algorithm is the default choice for the integrity check algorithm. Note that SHA-256 is also entering widespread usage."/>
       <min value="0"/>
       <max value="0"/>
-      <type>
-        <code value="code"/>
-      </type>
-      <binding>
-        <strength value="required"/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-IntegrityCheckAlgorithm"/>
-      </binding>
     </element>
-    <element id="ST.language">
-      <path value="ST.language"/>
-      <representation value="xmlAttr"/>
-      <label value="Language"/>
-      <definition value="For character based information the language property specifies the human language of the text."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="code"/>
-      </type>
-    </element>
-    <element id="ST.mediaType">
-      <path value="ST.mediaType"/>
+    <element id="ED.mediaType">
+      <path value="ED.mediaType"/>
       <representation value="xmlAttr"/>
       <label value="Media Type"/>
       <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
@@ -104,8 +65,8 @@
       </type>
       <fixedCode value="text/plain"/>
     </element>
-    <element id="ST.representation">
-      <path value="ST.representation"/>
+    <element id="ED.representation">
+      <path value="ED.representation"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -114,8 +75,8 @@
       </type>
       <fixedCode value="TXT"/>
     </element>
-    <element id="ST.data">
-      <path value="ST.data"/>
+    <element id="ED.data[x]">
+      <path value="ED.data[x]"/>
       <representation value="xmlText"/>
       <definition value="The string value"/>
       <min value="0"/>
@@ -124,25 +85,19 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="ST.reference">
-      <path value="ST.reference"/>
+    <element id="ED.reference">
+      <path value="ED.reference"/>
       <label value="Reference"/>
       <definition value="A telecommunication address (TEL), such as a URL for HTTP or FTP, which will resolve to precisely the same binary data that could as well have been provided as inline data."/>
       <min value="0"/>
       <max value="0"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/TEL"/>
-      </type>
     </element>
-    <element id="ST.thumbnail">
-      <path value="ST.thumbnail"/>
+    <element id="ED.thumbnail">
+      <path value="ED.thumbnail"/>
       <label value="Thumbnail"/>
       <definition value="An abbreviated rendition of the full data. A thumbnail requires significantly fewer resources than the full data, while still maintaining some distinctive similarity with the full data. A thumbnail is typically used with by-reference encapsulated data. It allows a user to select data more efficiently before actually downloading through the reference."/>
       <min value="0"/>
       <max value="0"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-      </type>
     </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
ED is a specialization of ANY

ST is currently a specialization of ED this should be however a constraint (a specialisation cannot make constraint and ST is a restriction on ED)
* changed ST to a constraint, Element id/path renamed to ED instead of SD
* removed form ST Elements which are not redefined in ED
* instead of ST.data which is a constraint to ED.data[x] the constraint to string is defined in ED.data[x]

ENXP is a specialization of ST
* nullFlavor removed, is defined in ANY
* ENXP.value is removed, the value of the xml Element is defined by the specialization of ED.data[x]

Added ADXP as an own HL7v3 Datatype as a specialization of ST with a qualifier
* adapted AD to used ADXP