### PR TITLE
allow xsi:type on observation.code

### DIFF
--- a/resources/Observation.xml
+++ b/resources/Observation.xml
@@ -65,6 +65,7 @@
       <path value="Observation.code"/>
       <min value="1"/>
       <max value="1"/>
+      <representation value="typeAttr"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
       </type>


### PR DESCRIPTION
the sample cda.xml in this project has an xsi:type attribute on Observation.code

```xml
<code xsi:type="CD" code="396275006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Osteoarthritis">
```
this pull requests enables the xsi:type representation, it is [allowed here](https://www.hl7.org/documentcenter/public_temp_FB82B26D-1C23-BA17-0C17A0A2334C8009/wg/inm/datatypes-its-xml20050714.htm) (xsi:type may be used at other times according to the XML Schema specification.), even it does not make much sense. 