### PR TITLE
ON type for Organization name

### DIFF
--- a/resources/CustodianOrganization.xml
+++ b/resources/CustodianOrganization.xml
@@ -74,7 +74,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ON"/>
       </type>
     </element>
     <element id="CustodianOrganization.telecom">

--- a/resources/EN.xml
+++ b/resources/EN.xml
@@ -36,12 +36,16 @@
       <path value="EN.use"/>
       <representation value="xmlAttr"/>
       <label value="Use Code"/>
-      <definition value="A set of codes advising a system or user which name in a set of names to select for a given purpose."/>
+      <definition value="A set of codes advising a system or user which name in a set of like names to select for a given purpose. A name without specific use code might be a default name useful for any purpose, but a name with a specific use code would be preferred for that respective purpose"/>
       <min value="0"/>
-      <max value="*"/>
+      <max value="1"/>
       <type>
         <code value="code"/>
       </type>
+      <binding>
+        <strength value="required"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityNameUse"/>
+      </binding>
     </element>
     <element id="EN.delimiter">
       <path value="EN.delimiter"/>

--- a/resources/ON.xml
+++ b/resources/ON.xml
@@ -19,7 +19,7 @@
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
-  <description value="A name for an organization. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for organization name values are &quot;Health Level Seven, Inc.&quot;, &quot;Hospital&quot;, etc. An organization name may be as simple as a character string or may consist of several person name parts, such as, &quot;Health Level 7&quot;, &quot;Inc.&quot;. ON differs from EN because certain person related name parts are not possible."/>
+  <description value="A name for an organization. A sequence of name parts. Examples for organization name values are &quot;Health Level Seven, Inc.&quot;, &quot;Hospital&quot;, etc. An organization name may be as simple as a character string or may consist of several person name parts, such as, &quot;Health Level 7&quot;, &quot;Inc.&quot;. ON differs from EN because certain person related name parts are not possible."/>
   <kind value="logical"/>
   <abstract value="false"/>
   <type value="ON"/>
@@ -28,16 +28,9 @@
   <differential>
     <element id="ON">
       <path value="ON"/>
-      <definition value="A name for an organization. A sequence of name parts, such as given name or family name, prefix, suffix, etc. Examples for organization name values are &quot;Health Level Seven, Inc.&quot;, &quot;Hospital&quot;, etc. An organization name may be as simple as a character string or may consist of several person name parts, such as, &quot;Health Level 7&quot;, &quot;Inc.&quot;. ON differs from EN because certain person related name parts are not possible."/>
+      <definition value="A name for an organization. A sequence of name parts. Examples for organization name values are &quot;Health Level Seven, Inc.&quot;, &quot;Hospital&quot;, etc. An organization name may be as simple as a character string or may consist of several person name parts, such as, &quot;Health Level 7&quot;, &quot;Inc.&quot;. ON differs from EN because certain person related name parts are not possible."/>
       <min value="1"/>
       <max value="*"/>
-    </element>
-    <element id="ON.use">
-      <path value="ON.use"/>
-      <binding>
-        <strength value="required"/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-OrganizationNameUse"/>
-      </binding>
     </element>
     <element id="ON.family">
       <path value="ON.family"/>

--- a/resources/Organization.xml
+++ b/resources/Organization.xml
@@ -74,7 +74,7 @@
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/ON"/>
       </type>
     </element>
     <element id="Organization.telecom">


### PR DESCRIPTION
organization.name is defined as ST, but this should be ON according to the schema (see also error message below when validating an example message):

<xs:element name="name" type="ON" minOccurs="0" maxOccurs="unbounded”/>

The ON and EN datatype have been adjusted as it is in the schema spec (cardinality, description).

Error @ /v3:ClinicalDocument/v3:recordTarget/v3:patientRole/v3:providerOrganization/v3:name (line 96, col19) : Undefined attribute '@use' on name for type http://hl7.org/fhir/cda/StructureDefinition/ST (properties = [ED.id, ED.nullFlavor, ED.charset, ED.compression, ED.integrityCheck, ED.integrityCheckAlgorithm, ED.language, ED.mediaType, ED.representation, ED.extension, ED.data[x], ED.reference, ED.thumbnail])