### PR TITLE
Consent fixed statusCode.code

### DIFF
--- a/resources/Consent.xml
+++ b/resources/Consent.xml
@@ -87,13 +87,18 @@
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
       </type>
-      <defaultValueCode value="completed"/>
-      <fixedCode value="completed"/>
-      
       <binding>
         <strength value="required"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActStatus"/>
       </binding>
+    </element>
+    <element id="Consent.statusCode.code">
+      <path value="Consent.statusCode.code"/>
+      <representation value="xmlAttr"/>
+      <min value="1"/>
+      <max value="1"/>
+      <defaultValueCode value="completed"/>
+      <fixedString value="completed"/>
     </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
```xml
	<consent>
			<code nullFlavor="OTH" codeSystem="2.16.756.5.30.2.1.1.2">
				<originalText>
					Mündliche Einwilligung während Konsultation vom 03.10.2017
				</originalText>
			</code>
			<statusCode code="completed"/>
		</consent>
```
With the current model statusCode gives an error:
Error @ ClinicalDocument.authorization[0].consent.statusCode (line 233, col34) : Value is 'null' but must be ‘completed'

statusCode is of type CS, moved the fixed completed to the code attribute.