### PR TITLE
xsi:type for ObservationMedia

### DIFF
--- a/resources/ObservationMedia.xml
+++ b/resources/ObservationMedia.xml
@@ -93,6 +93,7 @@
     </element>
     <element id="ObservationMedia.value">
       <path value="ObservationMedia.value"/>
+      <representation value="typeAttr"/>
       <min value="1"/>
       <max value="1"/>
       <type>


### PR DESCRIPTION
ObservationMedia can have an xsi:type (see CDA 4.3.5.6 <renderMultiMedia>), the attribute has been added to this pull request.

Error before pull request:
 Error @ /v3:ClinicalDocument/v3:component/v3:structuredBody/v3:component/v3:section/v3:entry/v3:observationMedia/v3:value (line 323, col52) : Undefined attribute '@xsi:type' on value for type http://hl7.org/fhir/cda/StructureDefinition/ED (properties = [ED.nullFlavor, ED.charset, ED.compression, ED.integrityCheck, ED.integrityCheckAlgorithm, ED.language, ED.mediaType, ED.representation, ED.data[x], ED.reference, ED.thumbnail])
