### PR TITLE
nullFlavor on Material

### DIFF
--- a/resources/Material.xml
+++ b/resources/Material.xml
@@ -63,6 +63,21 @@
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminerDetermined"/>
       </binding>
     </element>
+    <element id="Material.nullFlavor">
+      <path value="Material.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
     <element id="Material.templateId">
       <path value="Material.templateId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>


### PR DESCRIPTION
/v3:ClinicalDocument/v3:component/v3:structuredBody/v3:component/v3:section/v3:entry/v3:substanceAdministration/v3:entryRelationship/v3:substanceAdministration/v3:consumable/v3:manufacturedProduct/v3:manufacturedMaterial (line 296, col52) : Undefined attribute '@nullFlavor' on manufacturedMaterial for type http://hl7.org/fhir/cda/StructureDefinition/Material 

Material has an optional attribute NullFlavor:
	<xs:complexType name="POCD_MT000040.Material">
		<xs:sequence>
			<xs:element name="realmCode" type="CS" minOccurs="0" maxOccurs="unbounded"/>
			<xs:element name="typeId" type="POCD_MT000040.InfrastructureRoot.typeId" minOccurs="0"/>
			<xs:element name="templateId" type="II" minOccurs="0" maxOccurs="unbounded"/>
			<xs:element name="code" type="CE" minOccurs="0"/>
			<xs:element name="name" type="EN" minOccurs="0"/>
			<xs:element name="lotNumberText" type="ST" minOccurs="0"/>
		</xs:sequence>
		<xs:attribute name="nullFlavor" type="NullFlavor" use="optional"/>