### PR TITLE
substanceAdministration doseQuantity type

### DIFF
--- a/resources/SubstanceAdministration.xml
+++ b/resources/SubstanceAdministration.xml
@@ -184,7 +184,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/PQ"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_PQ"/>
       </type>
     </element>
     <element id="SubstanceAdministration.rateQuantity">


### PR DESCRIPTION

Error @ /v3:ClinicalDocument/v3:component/v3:structuredBody/v3:component/v3:section/v3:entry/v3:substanceAdministration/v3:doseQuantity (line 222, col29) : Undefined element 'center'

doseQuantity is currently defined as PQ but should be IVL_PQ:

			<xs:element name="doseQuantity" type="IVL_PQ" minOccurs="0"/>
