### PR TITLE
SXPR_TS comp not as choice

### DIFF
--- a/resources/SXPR_TS.xml
+++ b/resources/SXPR_TS.xml
@@ -22,8 +22,8 @@
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="SXPR_TS.comp[x]">
-      <path value="SXPR_TS.comp[x]"/>
+    <element id="SXPR_TS.comp">
+      <path value="SXPR_TS.comp"/>
       <representation value="typeAttr"/>
       <min value="1"/>
       <max value="*"/>


### PR DESCRIPTION
The SXPR_TS defines comp currently as a choice, however the type will not be in the elementname. Removed choice [x] equivalent concept as observation.value.

				<effectiveTime xsi:type="SXPR_TS" operator="A">
								<comp xsi:type="EIVL_TS">
									<event code='ACM' />
								</comp>
								<comp xsi:type="EIVL_TS" operator="I">
									<event code='ACV' />
								</comp>
							</effectiveTime>