### PR TITLE
Participant cardinalities and associatedEntity

### DIFF
--- a/resources/Participant.xml
+++ b/resources/Participant.xml
@@ -101,7 +101,7 @@
     </element>
     <element id="Participant.functionCode">
       <path value="Participant.functionCode"/>
-      <min value="1"/>
+      <min value="0"/>
       <max value="1"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
@@ -110,19 +110,19 @@
     </element>
     <element id="Participant.time">
       <path value="Participant.time"/>
-      <min value="1"/>
+      <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       
     </element>
-    <element id="Participant.assignedEntity">
-      <path value="Participant.assignedEntity"/>
+    <element id="Participant.associatedEntity">
+      <path value="Participant.associatedEntity"/>
       <min value="1"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/AssignedEntity"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/AssociatedEntity"/>
       </type>
     </element>
   </differential>


### PR DESCRIPTION
* changed min card. for functionCode and time to zero, time is IVL_TS
* changed assignedEntity to associatedEntity

```xml
	<xs:complexType name="POCD_MT000040.Participant1">
		<xs:sequence>
			<xs:element name="realmCode" type="CS" minOccurs="0" maxOccurs="unbounded"/>
			<xs:element name="typeId" type="POCD_MT000040.InfrastructureRoot.typeId" minOccurs="0"/>
			<xs:element name="templateId" type="II" minOccurs="0" maxOccurs="unbounded"/>
			<xs:element name="functionCode" type="CE" minOccurs="0"/>
			<xs:element name="time" type="IVL_TS" minOccurs="0"/>
			<xs:element name="associatedEntity" type="POCD_MT000040.AssociatedEntity"/>
		</xs:sequence>
		<xs:attribute name="nullFlavor" type="NullFlavor" use="optional"/>
		<xs:attribute name="typeCode" type="ParticipationType" use="required"/>
		<xs:attribute name="contextControlCode" type="ContextControl" use="optional" fixed="OP"/>
	</xs:complexType>
```

  Error @ ClinicalDocument.participant[0] (line 218, col30) : Profile http://hl7.org/fhir/cda/StructureDefinition/Participant, Element 'ClinicalDocument.participant[0].assignedEntity': minimum required = 1, but only found 0
  Error @ ClinicalDocument.participant[0] (line 218, col30) : Profile http://hl7.org/fhir/cda/StructureDefinition/Participant, Element 'ClinicalDocument.participant[0].functionCode': minimum required = 1, but only found 0
  Error @ /v3:ClinicalDocument/v3:participant (line 226, col37) : Undefined element 'associatedEntity'