### PR TITLE
effectiveTime SXCM_TS as default type

### DIFF
--- a/resources/SubstanceAdministration.xml
+++ b/resources/SubstanceAdministration.xml
@@ -116,12 +116,15 @@
     </element>
     <element id="SubstanceAdministration.effectiveTime">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype">
-        <valueString value="SXPR_TS"/>
+        <valueString value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
       </extension>
       <path value="SubstanceAdministration.effectiveTime"/>
       <representation value="typeAttr"/>
       <min value="0"/>
       <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
+      </type>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>

--- a/resources/Supply.xml
+++ b/resources/Supply.xml
@@ -107,12 +107,15 @@
     </element>
     <element id="Supply.effectiveTime">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype">
-        <valueString value="SXPR_TS"/>
+        <valueString value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
       </extension>
       <path value="Supply.effectiveTime"/>
       <representation value="typeAttr"/>
       <min value="0"/>
       <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
+      </type>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>


### PR DESCRIPTION
substanceAdministration and Supply have both a default type of SXCM_TS (not SXPR_TS) and the type needs to be absolute. 

Supply:
<xs:element name="effectiveTime" type="SXCM_TS" minOccurs="0" maxOccurs="unbounded"/>

SubstanceAdministration:
<xs:element name="effectiveTime" type="SXCM_TS" minOccurs="0" maxOccurs="unbounded"/>
