### PR TITLE
Observation.performer templateId

### DIFF
--- a/resources/Observation.xml
+++ b/resources/Observation.xml
@@ -381,6 +381,15 @@
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationPhysicalPerformer"/>
       </binding>
     </element>
+    <element id="Observation.performer.templateId">
+      <path value="Observation.performer.templateId"/>
+      <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
+      </type>
+    </element>
     <element id="Observation.performer.time">
       <path value="Observation.performer.time"/>
       <min value="0"/>


### PR DESCRIPTION
Another tempalteId I found in a sample .... (Observation.perfomer which is Performer2)

	<xs:complexType name="POCD_MT000040.Performer2">
		<xs:sequence>
			<xs:element name="realmCode" type="CS" minOccurs="0" maxOccurs="unbounded"/>
			<xs:element name="typeId" type="POCD_MT000040.InfrastructureRoot.typeId" minOccurs="0"/>
			<xs:element name="templateId" type="II" minOccurs="0" maxOccurs="unbounded"/>