### PR TITLE
ST as type specialization instead of constraint

### DIFF
--- a/input/resources/ST.xml
+++ b/input/resources/ST.xml
@@ -19,42 +19,42 @@
   <description value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="ED"/>
+  <type value="ST"/>
   <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
-  <derivation value="constraint"/>
+  <derivation value="specialization"/>
   <differential>
-    <element id="ED">
-      <path value="ED"/>
+    <element id="ST">
+      <path value="ST"/>
       <definition value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ED.compression">
-      <path value="ED.compression"/>
+    <element id="ST.compression">
+      <path value="ST.compression"/>
       <representation value="xmlAttr"/>
       <label value="Compression"/>
       <definition value="Indicates whether the raw byte data is compressed, and what compression algorithm was used."/>
       <min value="0"/>
       <max value="0"/>
     </element>
-    <element id="ED.integrityCheck">
-      <path value="ED.integrityCheck"/>
+    <element id="ST.integrityCheck">
+      <path value="ST.integrityCheck"/>
       <representation value="xmlAttr"/>
       <label value="Integrity Check"/>
       <definition value="The integrity check is a short binary value representing a cryptographically strong checksum that is calculated over the binary data. The purpose of this property, when communicated with a reference is for anyone to validate later whether the reference still resolved to the same data that the reference resolved to when the encapsulated data value with reference was created."/>
       <min value="0"/>
       <max value="0"/>
     </element>
-    <element id="ED.integrityCheckAlgorithm">
-      <path value="ED.integrityCheckAlgorithm"/>
+    <element id="ST.integrityCheckAlgorithm">
+      <path value="ST.integrityCheckAlgorithm"/>
       <representation value="xmlAttr"/>
       <label value="Integrity Check Algorithm"/>
       <definition value="Specifies the algorithm used to compute the integrityCheck value. The cryptographically strong checksum algorithm Secure Hash Algorithm-1 (SHA-1) is currently the industry standard. It has superseded the MD5 algorithm only a couple of years ago, when certain flaws in the security of MD5 were discovered. Currently the SHA-1 hash algorithm is the default choice for the integrity check algorithm. Note that SHA-256 is also entering widespread usage."/>
       <min value="0"/>
       <max value="0"/>
     </element>
-    <element id="ED.mediaType">
-      <path value="ED.mediaType"/>
+    <element id="ST.mediaType">
+      <path value="ST.mediaType"/>
       <representation value="xmlAttr"/>
       <label value="Media Type"/>
       <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
@@ -65,8 +65,8 @@
       </type>
       <fixedCode value="text/plain"/>
     </element>
-    <element id="ED.representation">
-      <path value="ED.representation"/>
+    <element id="ST.representation">
+      <path value="ST.representation"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -75,8 +75,8 @@
       </type>
       <fixedCode value="TXT"/>
     </element>
-    <element id="ED.data[x]">
-      <path value="ED.data[x]"/>
+    <element id="ST.data[x]">
+      <path value="ST.data[x]"/>
       <representation value="xmlText"/>
       <definition value="The string value"/>
       <min value="0"/>
@@ -85,15 +85,15 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="ED.reference">
-      <path value="ED.reference"/>
+    <element id="ST.reference">
+      <path value="ST.reference"/>
       <label value="Reference"/>
       <definition value="A telecommunication address (TEL), such as a URL for HTTP or FTP, which will resolve to precisely the same binary data that could as well have been provided as inline data."/>
       <min value="0"/>
       <max value="0"/>
     </element>
-    <element id="ED.thumbnail">
-      <path value="ED.thumbnail"/>
+    <element id="ST.thumbnail">
+      <path value="ST.thumbnail"/>
       <label value="Thumbnail"/>
       <definition value="An abbreviated rendition of the full data. A thumbnail requires significantly fewer resources than the full data, while still maintaining some distinctive similarity with the full data. A thumbnail is typically used with by-reference encapsulated data. It allows a user to select data more efficiently before actually downloading through the reference."/>
       <min value="0"/>


### PR DESCRIPTION
to define ST just as a constraint from me was an error, it gives a validation error:

> Type 'ST' is not an acceptable type for 'value' on property Observation.value

Defining ST as proper own type as the others and specialized from ED (instead constraint from ED) resolves the validation problem.

