### PR TITLE
allow xsi:type on Observation.text

### DIFF
--- a/resources/Observation.xml
+++ b/resources/Observation.xml
@@ -104,6 +104,7 @@
       <path value="Observation.text"/>
       <min value="0"/>
       <max value="1"/>
+      <representation value="typeAttr"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
       </type>


### PR DESCRIPTION
austrian samples have xsi:type on Observation.text, it is not very useful, but it also not forbidden according to the spec. adding it resolves validation error.