### PR TITLE
v3 datatypes _ instead of -

### DIFF
--- a/input/resources/AD.xml
+++ b/input/resources/AD.xml
@@ -906,7 +906,7 @@
     </element>
     <element id="AD.useablePeriod[x]">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype">
-        <valueString value="SXPR-TS"/>
+        <valueString value="SXPR_TS"/>
       </extension>
       <path value="AD.useablePeriod[x]"/>
       <representation value="typeAttr"/>
@@ -915,16 +915,16 @@
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
       </type>
     </element>
   </differential>

--- a/input/resources/Act.xml
+++ b/input/resources/Act.xml
@@ -110,7 +110,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Act.priorityCode">
@@ -254,7 +254,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Act.performer.modeCode">
@@ -380,7 +380,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Act.participant.awarenessCode">

--- a/input/resources/Criterion.xml
+++ b/input/resources/Criterion.xml
@@ -135,19 +135,19 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-PQ"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_PQ"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
       </type>
     </element>
   </differential>

--- a/input/resources/EIVL-TS.xml
+++ b/input/resources/EIVL-TS.xml
@@ -10,27 +10,27 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
     <valueUri value="urn:hl7-org:v3"/>
   </extension>
-  <url value="http://hl7.org/fhir/cda/StructureDefinition/EIVL-TS"/>
-  <name value="EIVL-TS"/>
-  <title value="EIVL-TS: EventRelatedPeriodicInterval (V3 Data Type)"/>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
+  <name value="EIVL_TS"/>
+  <title value="EIVL_TS: EventRelatedPeriodicInterval (V3 Data Type)"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
   <description value="Specifies a periodic interval of time where the recurrence is based on activities of daily living or other important events that are time-related but not fully determined by time."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="EIVL-TS"/>
-  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/SXCM-TS"/>
+  <type value="EIVL_TS"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="EIVL-TS">
-      <path value="EIVL-TS"/>
+    <element id="EIVL_TS">
+      <path value="EIVL_TS"/>
       <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="EIVL-TS.event">
-      <path value="EIVL-TS.event"/>
+    <element id="EIVL_TS.event">
+      <path value="EIVL_TS.event"/>
       <label value="Event"/>
       <definition value="A code for a common (periodical) activity of daily living based on which the event related periodic interval is specified."/>
       <min value="0"/>
@@ -39,14 +39,14 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
       </type>
     </element>
-    <element id="EIVL-TS.offset">
-      <path value="EIVL-TS.offset"/>
+    <element id="EIVL_TS.offset">
+      <path value="EIVL_TS.offset"/>
       <label value="Offset"/>
       <definition value="An interval of elapsed time (duration, not absolute point in time) that marks the offsets for the beginning, width and end of the event-related periodic interval measured from the time each such event actually occurred."/>
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-PQ"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_PQ"/>
       </type>
     </element>
   </differential>

--- a/input/resources/EN.xml
+++ b/input/resources/EN.xml
@@ -103,7 +103,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
   </differential>

--- a/input/resources/EncompassingEncounter.xml
+++ b/input/resources/EncompassingEncounter.xml
@@ -96,7 +96,7 @@
       <min value="1"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       
     </element>
@@ -178,7 +178,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="EncompassingEncounter.encounterParticipant.assignedEntity">

--- a/input/resources/Encounter.xml
+++ b/input/resources/Encounter.xml
@@ -108,7 +108,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Encounter.priorityCode">
@@ -244,7 +244,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Encounter.performer.modeCode">
@@ -374,7 +374,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Encounter.participant.awarenessCode">

--- a/input/resources/IVL-INT.xml
+++ b/input/resources/IVL-INT.xml
@@ -4,32 +4,32 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
     <valueUri value="urn:hl7-org:v3"/>
   </extension>
-  <url value="http://hl7.org/fhir/cda/StructureDefinition/IVL-INT"/>
-  <name value="IVL-INT"/>
-  <title value="IVL-INT: Interval (V3 Data Type)"/>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/IVL_INT"/>
+  <name value="IVL_INT"/>
+  <title value="IVL_INT: Interval (V3 Data Type)"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
   <description value="A set of consecutive values of an ordered base data type."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="IVL-INT"/>
+  <type value="IVL_INT"/>
   <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/ANY"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="IVL-INT">
-      <path value="IVL-INT"/>
+    <element id="IVL_INT">
+      <path value="IVL_INT"/>
       <definition value="Interval of integers"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="IVL-INT.value">
-      <path value="IVL-INT.value"/>
+    <element id="IVL_INT.value">
+      <path value="IVL_INT.value"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="IVL-INT.value"/>
+        <path value="IVL_INT.value"/>
         <min value="0"/>
         <max value="1"/>
       </base>
@@ -37,8 +37,8 @@
         <code value="integer"/>
       </type>
     </element>
-    <element id="IVL-INT.low">
-      <path value="IVL-INT.low"/>
+    <element id="IVL_INT.low">
+      <path value="IVL_INT.low"/>
       <label value="Low Boundary"/>
       <definition value="This is the low limit of the interval."/>
       <min value="0"/>
@@ -47,8 +47,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/INT"/>
       </type>
     </element>
-    <element id="IVL-INT.high">
-      <path value="IVL-INT.high"/>
+    <element id="IVL_INT.high">
+      <path value="IVL_INT.high"/>
       <label value="High Boundary"/>
       <definition value="This is the high limit of the interval."/>
       <min value="0"/>
@@ -57,8 +57,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/INT"/>
       </type>
     </element>
-    <element id="IVL-INT.width">
-      <path value="IVL-INT.width"/>
+    <element id="IVL_INT.width">
+      <path value="IVL_INT.width"/>
       <label value="Width"/>
       <definition value="The difference between high and low boundary. The purpose of distinguishing a width property is to handle all cases of incomplete information symmetrically. In any interval representation only two of the three properties high, low, and width need to be stated and the third can be derived."/>
       <min value="0"/>
@@ -67,8 +67,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="IVL-INT.center">
-      <path value="IVL-INT.center"/>
+    <element id="IVL_INT.center">
+      <path value="IVL_INT.center"/>
       <label value="Central Value"/>
       <definition value="The arithmetic mean of the interval (low plus high divided by 2). The purpose of distinguishing the center as a semantic property is for conversions of intervals from and to point values."/>
       <min value="0"/>

--- a/input/resources/IVL-PQ.xml
+++ b/input/resources/IVL-PQ.xml
@@ -4,33 +4,33 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
     <valueUri value="urn:hl7-org:v3"/>
   </extension>
-  <url value="http://hl7.org/fhir/cda/StructureDefinition/IVL-PQ"/>
-  <name value="IVL-PQ"/>
-  <title value="IVL-PQ: Interval (V3 Data Type)"/>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/IVL_PQ"/>
+  <name value="IVL_PQ"/>
+  <title value="IVL_PQ: Interval (V3 Data Type)"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
   <description value="A set of consecutive values of an ordered base data type."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="IVL-PQ"/>
+  <type value="IVL_PQ"/>
   <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/ANY"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="IVL-PQ">
-      <path value="IVL-PQ"/>
+    <element id="IVL_PQ">
+      <path value="IVL_PQ"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="IVL-PQ.unit">
-      <path value="IVL-PQ.unit"/>
+    <element id="IVL_PQ.unit">
+      <path value="IVL_PQ.unit"/>
       <representation value="xmlAttr"/>
       <label value="Unit of Measure"/>
       <definition value="The unit of measure specified in the Unified Code for Units of Measure (UCUM) []."/>
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="IVL-PQ.unit"/>
+        <path value="IVL_PQ.unit"/>
         <min value="0"/>
         <max value="1"/>
       </base>
@@ -38,8 +38,8 @@
         <code value="code"/>
       </type>
     </element>
-    <element id="IVL-PQ.value">
-      <path value="IVL-PQ.value"/>
+    <element id="IVL_PQ.value">
+      <path value="IVL_PQ.value"/>
       <representation value="xmlAttr"/>
       <label value="Maginitude Value"/>
       <definition value="The magnitude of the quantity measured in terms of the unit."/>
@@ -54,8 +54,8 @@
         <code value="decimal"/>
       </type>
     </element>
-    <element id="IVL-PQ.low">
-      <path value="IVL-PQ.low"/>
+    <element id="IVL_PQ.low">
+      <path value="IVL_PQ.low"/>
       <label value="Low Boundary"/>
       <definition value="This is the low limit of the interval."/>
       <min value="0"/>
@@ -64,8 +64,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="IVL-PQ.high">
-      <path value="IVL-PQ.high"/>
+    <element id="IVL_PQ.high">
+      <path value="IVL_PQ.high"/>
       <label value="High Boundary"/>
       <definition value="This is the high limit of the interval."/>
       <min value="0"/>
@@ -74,8 +74,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="IVL-PQ.width">
-      <path value="IVL-PQ.width"/>
+    <element id="IVL_PQ.width">
+      <path value="IVL_PQ.width"/>
       <label value="Width"/>
       <definition value="The difference between high and low boundary. The purpose of distinguishing a width property is to handle all cases of incomplete information symmetrically. In any interval representation only two of the three properties high, low, and width need to be stated and the third can be derived."/>
       <min value="0"/>
@@ -84,8 +84,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="IVL-PQ.center">
-      <path value="IVL-PQ.center"/>
+    <element id="IVL_PQ.center">
+      <path value="IVL_PQ.center"/>
       <label value="Central Value"/>
       <definition value="The arithmetic mean of the interval (low plus high divided by 2). The purpose of distinguishing the center as a semantic property is for conversions of intervals from and to point values."/>
       <min value="0"/>

--- a/input/resources/IVL-TS.xml
+++ b/input/resources/IVL-TS.xml
@@ -4,26 +4,26 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
     <valueUri value="urn:hl7-org:v3"/>
   </extension>
-  <url value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
-  <name value="IVL-TS"/>
-  <title value="IVL-TS: Interval (V3 Data Type)"/>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
+  <name value="IVL_TS"/>
+  <title value="IVL_TS: Interval (V3 Data Type)"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
   <description value="A set of consecutive values of an ordered base data type."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="IVL-TS"/>
-  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/SXCM-TS"/>
+  <type value="IVL_TS"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="IVL-TS">
-      <path value="IVL-TS"/>
+    <element id="IVL_TS">
+      <path value="IVL_TS"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="IVL-TS.low">
-      <path value="IVL-TS.low"/>
+    <element id="IVL_TS.low">
+      <path value="IVL_TS.low"/>
       <label value="Low Boundary"/>
       <definition value="This is the low limit of the interval."/>
       <min value="0"/>
@@ -32,8 +32,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
       </type>
     </element>
-    <element id="IVL-TS.high">
-      <path value="IVL-TS.high"/>
+    <element id="IVL_TS.high">
+      <path value="IVL_TS.high"/>
       <label value="High Boundary"/>
       <definition value="This is the high limit of the interval."/>
       <min value="0"/>
@@ -42,8 +42,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
       </type>
     </element>
-    <element id="IVL-TS.width">
-      <path value="IVL-TS.width"/>
+    <element id="IVL_TS.width">
+      <path value="IVL_TS.width"/>
       <label value="Width"/>
       <definition value="The difference between high and low boundary. The purpose of distinguishing a width property is to handle all cases of incomplete information symmetrically. In any interval representation only two of the three properties high, low, and width need to be stated and the third can be derived."/>
       <min value="0"/>
@@ -52,8 +52,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="IVL-TS.center">
-      <path value="IVL-TS.center"/>
+    <element id="IVL_TS.center">
+      <path value="IVL_TS.center"/>
       <label value="Central Value"/>
       <definition value="The arithmetic mean of the interval (low plus high divided by 2). The purpose of distinguishing the center as a semantic property is for conversions of intervals from and to point values."/>
       <min value="0"/>

--- a/input/resources/MaintainedEntity.xml
+++ b/input/resources/MaintainedEntity.xml
@@ -59,7 +59,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="MaintainedEntity.maintainingPerson">

--- a/input/resources/Observation.xml
+++ b/input/resources/Observation.xml
@@ -126,7 +126,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Observation.priorityCode">
@@ -146,7 +146,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-INT"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_INT"/>
       </type>
     </element>
     <element id="Observation.languageCode">
@@ -215,22 +215,22 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-PQ"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_PQ"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/RTO-PQ-PQ"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/RTO_PQ_PQ"/>
       </type>
     </element>
     <element id="Observation.interpretationCode">
@@ -396,7 +396,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Observation.performer.modeCode">
@@ -526,7 +526,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Observation.participant.awarenessCode">

--- a/input/resources/ObservationMedia.xml
+++ b/input/resources/ObservationMedia.xml
@@ -231,7 +231,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="ObservationMedia.performer.modeCode">
@@ -361,7 +361,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="ObservationMedia.participant.awarenessCode">

--- a/input/resources/ObservationRange.xml
+++ b/input/resources/ObservationRange.xml
@@ -135,19 +135,19 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-PQ"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_PQ"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
       </type>
     </element>
     <element id="ObservationRange.interpretationCode">

--- a/input/resources/OrganizationPartOf.xml
+++ b/input/resources/OrganizationPartOf.xml
@@ -79,7 +79,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="OrganizationPartOf.wholeOrganization">

--- a/input/resources/Organizer.xml
+++ b/input/resources/Organizer.xml
@@ -102,7 +102,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Organizer.component">
@@ -345,7 +345,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Organizer.performer.modeCode">
@@ -475,7 +475,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Organizer.participant.awarenessCode">

--- a/input/resources/PIVL-TS.xml
+++ b/input/resources/PIVL-TS.xml
@@ -10,37 +10,37 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
     <valueUri value="urn:hl7-org:v3"/>
   </extension>
-  <url value="http://hl7.org/fhir/cda/StructureDefinition/PIVL-TS"/>
-  <name value="PIVL-TS"/>
-  <title value="PIVL-TS: PeriodicIntervalOfTime (V3 Data Type)"/>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
+  <name value="PIVL_TS"/>
+  <title value="PIVL_TS: PeriodicIntervalOfTime (V3 Data Type)"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
   <description value="An interval of time that recurs periodically. Periodic intervals have two properties, phase and period. The phase specifies the &quot;interval prototype&quot; that is repeated every period."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="PIVL-TS"/>
-  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/SXCM-TS"/>
+  <type value="PIVL_TS"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="PIVL-TS">
-      <path value="PIVL-TS"/>
+    <element id="PIVL_TS">
+      <path value="PIVL_TS"/>
       <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="PIVL-TS.phase">
-      <path value="PIVL-TS.phase"/>
+    <element id="PIVL_TS.phase">
+      <path value="PIVL_TS.phase"/>
       <label value="Phase"/>
       <definition value="A prototype of the repeating interval, specifying the duration of each occurrence and anchors the periodic interval sequence at a certain point in time."/>
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
-    <element id="PIVL-TS.period">
-      <path value="PIVL-TS.period"/>
+    <element id="PIVL_TS.period">
+      <path value="PIVL_TS.period"/>
       <label value="Period"/>
       <definition value="A time duration specifying as a reciprocal measure of the frequency at which the periodic interval repeats."/>
       <min value="0"/>
@@ -49,8 +49,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="PIVL-TS.alignment">
-      <path value="PIVL-TS.alignment"/>
+    <element id="PIVL_TS.alignment">
+      <path value="PIVL_TS.alignment"/>
       <representation value="xmlAttr"/>
       <label value="Alignment to the Calendar"/>
       <definition value="Specifies if and how the repetitions are aligned to the cycles of the underlying calendar (e.g., to distinguish every 30 days from &quot;the 5th of every month&quot;.) A non-aligned periodic interval recurs independently from the calendar. An aligned periodic interval is synchronized with the calendar."/>
@@ -60,8 +60,8 @@
         <code value="code"/>
       </type>
     </element>
-    <element id="PIVL-TS.institutionSpecified">
-      <path value="PIVL-TS.institutionSpecified"/>
+    <element id="PIVL_TS.institutionSpecified">
+      <path value="PIVL_TS.institutionSpecified"/>
       <representation value="xmlAttr"/>
       <label value="Institution Specified Timing"/>
       <definition value="Indicates whether the exact timing is up to the party executing the schedule (e.g., to distinguish &quot;every 8 hours&quot; from &quot;3 times a day&quot;.)"/>

--- a/input/resources/Participant.xml
+++ b/input/resources/Participant.xml
@@ -113,7 +113,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       
     </element>

--- a/input/resources/Procedure.xml
+++ b/input/resources/Procedure.xml
@@ -115,7 +115,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Procedure.priorityCode">
@@ -290,7 +290,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Procedure.performer.modeCode">
@@ -420,7 +420,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Procedure.participant.awarenessCode">

--- a/input/resources/RTO-PQ-PQ.xml
+++ b/input/resources/RTO-PQ-PQ.xml
@@ -4,26 +4,26 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
     <valueUri value="urn:hl7-org:v3"/>
   </extension>
-  <url value="http://hl7.org/fhir/cda/StructureDefinition/RTO-PQ-PQ"/>
-  <name value="RTO-PQ-PQ"/>
-  <title value="RTO-PQ-PQ: Ratio (V3 Data Type)"/>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/RTO_PQ_PQ"/>
+  <name value="RTO_PQ_PQ"/>
+  <title value="RTO_PQ_PQ: Ratio (V3 Data Type)"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
   <description value="A quantity constructed as the quotient of a numerator quantity divided by a denominator quantity. Common factors in the numerator and denominator are not automatically cancelled out. The data type supports titers (e.g., &quot;1:128&quot;) and other quantities produced by laboratories that truly represent ratios. Ratios are not simply &quot;structured numerics&quot;, particularly blood pressure measurements (e.g. &quot;120/60&quot;) are not ratios. In many cases the should be used instead of the ."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="RTO-PQ-PQ"/>
+  <type value="RTO_PQ_PQ"/>
   <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/QTY"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="RTO-PQ-PQ">
-      <path value="RTO-PQ-PQ"/>
+    <element id="RTO_PQ_PQ">
+      <path value="RTO_PQ_PQ"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="RTO-PQ-PQ.numerator">
-      <path value="RTO-PQ-PQ.numerator"/>
+    <element id="RTO_PQ_PQ.numerator">
+      <path value="RTO_PQ_PQ.numerator"/>
       <label value="Numerator"/>
       <definition value="The quantity that is being divided in the ratio. The default is the integer number 1 (one.)"/>
       <min value="0"/>
@@ -32,8 +32,8 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="RTO-PQ-PQ.denominator">
-      <path value="RTO-PQ-PQ.denominator"/>
+    <element id="RTO_PQ_PQ.denominator">
+      <path value="RTO_PQ_PQ.denominator"/>
       <label value="Denominator"/>
       <definition value="The quantity that devides the numerator in the ratio. The default is the integer number 1 (one.) The denominator must not be zero."/>
       <min value="0"/>

--- a/input/resources/RegionOfInterest.xml
+++ b/input/resources/RegionOfInterest.xml
@@ -226,7 +226,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="RegionOfInterest.performer.modeCode">
@@ -356,7 +356,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="RegionOfInterest.participant.awarenessCode">

--- a/input/resources/RelatedEntity.xml
+++ b/input/resources/RelatedEntity.xml
@@ -84,7 +84,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="RelatedEntity.relatedPerson">

--- a/input/resources/SXCM-TS.xml
+++ b/input/resources/SXCM-TS.xml
@@ -4,26 +4,26 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
     <valueUri value="urn:hl7-org:v3"/>
   </extension>
-  <url value="http://hl7.org/fhir/cda/StructureDefinition/SXCM-TS"/>
-  <name value="SXCM-TS"/>
-  <title value="SXCM-TS: GeneralTimingSpecification (V3 Data Type)"/>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
+  <name value="SXCM_TS"/>
+  <title value="SXCM_TS: GeneralTimingSpecification (V3 Data Type)"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
   <description value="A set of points in time, specifying the timing of events and actions and the cyclical validity-patterns that may exist for certain kinds of information, such as phone numbers (evening, daytime), addresses (so called &quot;snowbirds,&quot; residing closer to the equator during winter and farther from the equator during summer) and office hours."/>
   <kind value="logical"/>
   <abstract value="true"/>
-  <type value="SXCM-TS"/>
+  <type value="SXCM_TS"/>
   <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="SXCM-TS">
-      <path value="SXCM-TS"/>
+    <element id="SXCM_TS">
+      <path value="SXCM_TS"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="SXCM-TS.operator">
-      <path value="SXCM-TS.operator"/>
+    <element id="SXCM_TS.operator">
+      <path value="SXCM_TS.operator"/>
       <representation value="xmlAttr"/>
       <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
       <min value="0"/>

--- a/input/resources/SXPR-TS.xml
+++ b/input/resources/SXPR-TS.xml
@@ -4,40 +4,40 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
     <valueUri value="urn:hl7-org:v3"/>
   </extension>
-  <url value="http://hl7.org/fhir/cda/StructureDefinition/SXPR-TS"/>
-  <name value="SXPR-TS"/>
-  <title value="SXPR-TS: Component part of GTS (V3 Data Type)"/>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
+  <name value="SXPR_TS"/>
+  <title value="SXPR_TS: Component part of GTS (V3 Data Type)"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
   <description value="A set-component that is itself made up of set-components that are evaluated as one value"/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="SXPR-TS"/>
-  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/SXCM-TS"/>
+  <type value="SXPR_TS"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="SXPR-TS">
-      <path value="SXPR-TS"/>
+    <element id="SXPR_TS">
+      <path value="SXPR_TS"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="SXPR-TS.comp">
-      <path value="SXPR-TS.comp"/>
+    <element id="SXPR_TS.comp">
+      <path value="SXPR_TS.comp"/>
       <representation value="typeAttr"/>
       <min value="1"/>
       <max value="*"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
       </type>
     </element>
   </differential>

--- a/input/resources/ServiceEvent.xml
+++ b/input/resources/ServiceEvent.xml
@@ -92,7 +92,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="ServiceEvent.performer">
@@ -130,7 +130,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="ServiceEvent.performer.assignedEntity">

--- a/input/resources/SubstanceAdministration.xml
+++ b/input/resources/SubstanceAdministration.xml
@@ -116,26 +116,26 @@
     </element>
     <element id="SubstanceAdministration.effectiveTime">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype">
-        <valueString value="http://hl7.org/fhir/cda/StructureDefinition/SXCM-TS"/>
+        <valueString value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
       </extension>
       <path value="SubstanceAdministration.effectiveTime"/>
       <representation value="typeAttr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXCM-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
       </type>
     </element>
     <element id="SubstanceAdministration.priorityCode">
@@ -155,7 +155,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-INT"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_INT"/>
       </type>
     </element>
     <element id="SubstanceAdministration.routeCode">
@@ -187,7 +187,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-PQ"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_PQ"/>
       </type>
     </element>
     <element id="SubstanceAdministration.rateQuantity">
@@ -195,7 +195,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-PQ"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_PQ"/>
       </type>
     </element>
     <element id="SubstanceAdministration.maxDoseQuantity">
@@ -203,7 +203,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/RTO-PQ-PQ"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/RTO_PQ_PQ"/>
       </type>
     </element>
     <element id="SubstanceAdministration.administrationUnitCode">
@@ -371,7 +371,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="SubstanceAdministration.performer.modeCode">
@@ -501,7 +501,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="SubstanceAdministration.participant.awarenessCode">

--- a/input/resources/Supply.xml
+++ b/input/resources/Supply.xml
@@ -107,26 +107,26 @@
     </element>
     <element id="Supply.effectiveTime">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype">
-        <valueString value="http://hl7.org/fhir/cda/StructureDefinition/SXCM-TS"/>
+        <valueString value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
       </extension>
       <path value="Supply.effectiveTime"/>
       <representation value="typeAttr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXCM-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXCM_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
       </type>
     </element>
     <element id="Supply.priorityCode">
@@ -146,7 +146,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-INT"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_INT"/>
       </type>
     </element>
     <element id="Supply.independentInd">
@@ -170,7 +170,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Supply.product">
@@ -328,7 +328,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Supply.performer.modeCode">
@@ -458,7 +458,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
     </element>
     <element id="Supply.participant.awarenessCode">

--- a/input/resources/TEL.xml
+++ b/input/resources/TEL.xml
@@ -39,7 +39,7 @@
     </element>
     <element id="TEL.useablePeriod">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype">
-        <valueString value="SXPR-TS"/>
+        <valueString value="SXPR_TS"/>
       </extension>
       <path value="TEL.useablePeriod"/>
       <representation value="typeAttr"/>
@@ -48,16 +48,16 @@
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/EIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PIVL_TS"/>
       </type>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR-TS"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR_TS"/>
       </type>
     </element>
     <element id="TEL.use">


### PR DESCRIPTION
The V3 Datatypes have been redefined in the Logical Model with [commit](https://github.com/HL7/cda-core-2.0/commit/09b9983b08417da50d8a10da2c890b26e4082b64#diff-5b26eeac324d4dc5e55d89701e481abf) from the HL7 V3 typename to
a - variation, e.g: EIVL-TS instead of EIVL_TS. The change may be due to the fact that in an id element the _ character is not allowed. However for url and type which both have an uri datatype the restriction does not hold.

Changing the type name from _ to - provides the following challenges:
* For parsers and serializers it is now not clear how to handle any xsi:type declaration because the CDA uses the V3 type name, this is now hidden knowledge
* The FHIR mapping language cannot work with character - in type names:  in the source parameter the type which can be specified has to be ([A-Za-z] | '_')([A-Za-z0-9] | '_’)*, where a character - is not allowed.

This pull requests changes the url and type back to the _ original type name. It does not change the id with -, because otherwise the IGPublisher will fail because it checks an id constraint for the implementation guide. 

The following errors will be produced for each _ type:
* Conformance resource /github/cda-core-2.0/input/resources/IVL-TS.xml - the canonical URL (http://hl7.org/fhir/cda/StructureDefinition/IVL-TS) does not match the URL (http://hl7.org/fhir/cda/StructureDefinition/IVL_TS)
* Resource id/url mismatch: IVL-TS/http://hl7.org/fhir/cda/StructureDefinition/IVL_TS
* URL Mismatch http://hl7.org/fhir/cda/StructureDefinition/IVL-TS vs http://hl7.org/fhir/cda/StructureDefinition/IVL_TS