### PR TITLE
Rename extensions to sdtcElementName

### DIFF
--- a/input/resources/AssignedAuthor.xml
+++ b/input/resources/AssignedAuthor.xml
@@ -60,9 +60,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="AssignedAuthor.identifiedBy">
+    <element id="AssignedAuthor.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="AssignedAuthor.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/AssignedAuthor.xml
+++ b/input/resources/AssignedAuthor.xml
@@ -67,7 +67,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="AssignedAuthor.identifiedBy"/>
+      <path value="AssignedAuthor.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/AssignedEntity.xml
+++ b/input/resources/AssignedEntity.xml
@@ -53,9 +53,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="AssignedEntity.identifiedBy">
+    <element id="AssignedEntity.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="AssignedEntity.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/AssignedEntity.xml
+++ b/input/resources/AssignedEntity.xml
@@ -60,7 +60,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="AssignedEntity.identifiedBy"/>
+      <path value="AssignedEntity.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/AssociatedEntity.xml
+++ b/input/resources/AssociatedEntity.xml
@@ -58,9 +58,11 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="AssociatedEntity.identifiedBy">
+    <element id="AssociatedEntity.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension><extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="AssociatedEntity.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/AssociatedEntity.xml
+++ b/input/resources/AssociatedEntity.xml
@@ -64,7 +64,7 @@
       </extension><extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="AssociatedEntity.identifiedBy"/>
+      <path value="AssociatedEntity.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/Authenticator.xml
+++ b/input/resources/Authenticator.xml
@@ -102,9 +102,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
       </type>
     </element>
-    <element id="Authenticator.signatureText">
+    <element id="Authenticator.sdtcSignatureText">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="signatureText"/>
       </extension>
       <path value="Authenticator.signatureText"/>
       <short value="sdtc:signatureText" />

--- a/input/resources/Authenticator.xml
+++ b/input/resources/Authenticator.xml
@@ -109,8 +109,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="signatureText"/>
       </extension>
-      <path value="Authenticator.signatureText"/>
-      <short value="sdtc:signatureText" />
+      <path value="Authenticator.sdtcSignatureText"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/CD.xml
+++ b/input/resources/CD.xml
@@ -84,9 +84,12 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.valueSet">
+    <element id="CD.sdtcValueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="valueSet"/>
       </extension>
       <path value="CD.valueSet"/>
       <representation value="xmlAttr"/>
@@ -102,9 +105,12 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CD.valueSetVersion">
+    <element id="CD.sdtcValueSetVersion">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="valueSetVersion"/>
       </extension>
       <path value="CD.valueSetVersion"/>
       <representation value="xmlAttr"/>

--- a/input/resources/CD.xml
+++ b/input/resources/CD.xml
@@ -91,7 +91,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="valueSet"/>
       </extension>
-      <path value="CD.valueSet"/>
+      <path value="CD.sdtcValueSet"/>
       <representation value="xmlAttr"/>
       <definition value="The valueSet extension adds an attribute for elements with a CD dataType which indicates the particular value set constraining the coded concept."/>
       <min value="0"/>
@@ -112,7 +112,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="valueSetVersion"/>
       </extension>
-      <path value="CD.valueSetVersion"/>
+      <path value="CD.sdtcValueSetVersion"/>
       <representation value="xmlAttr"/>
       <definition value="The valueSetVersion extension adds an attribute for elements with a CD dataType which indicates the version of the particular value set constraining the coded concept."/>
       <min value="0"/>

--- a/input/resources/CS.xml
+++ b/input/resources/CS.xml
@@ -69,9 +69,12 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CS.valueSet">
+    <element id="CS.sdtcValueSet">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="valueSet"/>
       </extension>
       <path value="CS.valueSet"/>
       <representation value="xmlAttr"/>
@@ -81,9 +84,12 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="CS.valueSetVersion">
+    <element id="CS.sdtcValueSetVersion">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="valueSetVersion"/>
       </extension>
       <path value="CS.valueSetVersion"/>
       <representation value="xmlAttr"/>

--- a/input/resources/CS.xml
+++ b/input/resources/CS.xml
@@ -76,7 +76,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="valueSet"/>
       </extension>
-      <path value="CS.valueSet"/>
+      <path value="CS.sdtcValueSet"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -91,7 +91,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="valueSetVersion"/>
       </extension>
-      <path value="CS.valueSetVersion"/>
+      <path value="CS.sdtcValueSetVersion"/>
       <representation value="xmlAttr"/>
       <definition value="The valueSetVersion extension adds an attribute for elements with a CD dataType which indicates the version of the particular value set constraining the coded concept."/>
       <min value="0"/>

--- a/input/resources/EncompassingEncounter.xml
+++ b/input/resources/EncompassingEncounter.xml
@@ -107,7 +107,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="admissionReferralSourceCode"/>
       </extension>
-      <path value="EncompassingEncounter.admissionReferralSourceCode"/>
+      <path value="EncompassingEncounter.sdtcAdmissionReferralSourceCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/EncompassingEncounter.xml
+++ b/input/resources/EncompassingEncounter.xml
@@ -100,9 +100,12 @@
       </type>
       
     </element>
-    <element id="EncompassingEncounter.admissionReferralSourceCode">
+    <element id="EncompassingEncounter.sdtcAdmissionReferralSourceCode">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="admissionReferralSourceCode"/>
       </extension>
       <path value="EncompassingEncounter.admissionReferralSourceCode"/>
       <min value="0"/>

--- a/input/resources/Guardian.xml
+++ b/input/resources/Guardian.xml
@@ -62,9 +62,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="Guardian.identifiedBy">
+    <element id="Guardian.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="Guardian.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/Guardian.xml
+++ b/input/resources/Guardian.xml
@@ -69,7 +69,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="Guardian.identifiedBy"/>
+      <path value="Guardian.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/HealthCareFacility.xml
+++ b/input/resources/HealthCareFacility.xml
@@ -59,7 +59,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="HealthCareFacility.identifiedBy"/>
+      <path value="HealthCareFacility.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/HealthCareFacility.xml
+++ b/input/resources/HealthCareFacility.xml
@@ -52,9 +52,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="HealthCareFacility.identifiedBy">
+    <element id="HealthCareFacility.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="HealthCareFacility.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/IdentifiedBy.xml
+++ b/input/resources/IdentifiedBy.xml
@@ -50,7 +50,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="alternateIdentification"/>
       </extension>
-      <path value="IdentifiedBy.alternateIdentification" />
+      <path value="IdentifiedBy.sdtcAlternateIdentification" />
       <min value="1" />
       <max value="1" />
       <type>

--- a/input/resources/IdentifiedBy.xml
+++ b/input/resources/IdentifiedBy.xml
@@ -43,9 +43,12 @@
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-RoleLinkType" />
       </binding>
     </element>
-    <element id="IdentifiedBy.alternateIdentification">
+    <element id="IdentifiedBy.sdtcAlternateIdentification">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="alternateIdentification"/>
       </extension>
       <path value="IdentifiedBy.alternateIdentification" />
       <min value="1" />

--- a/input/resources/IntendedRecipient.xml
+++ b/input/resources/IntendedRecipient.xml
@@ -55,7 +55,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="IntendedRecipient.identifiedBy"/>
+      <path value="IntendedRecipient.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/IntendedRecipient.xml
+++ b/input/resources/IntendedRecipient.xml
@@ -48,9 +48,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="IntendedRecipient.identifiedBy">
+    <element id="IntendedRecipient.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="IntendedRecipient.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/LegalAuthenticator.xml
+++ b/input/resources/LegalAuthenticator.xml
@@ -125,7 +125,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="signatureText"/>
       </extension>
-      <path value="LegalAuthenticator.signatureText"/>
+      <path value="LegalAuthenticator.sdtcSignatureText"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/LegalAuthenticator.xml
+++ b/input/resources/LegalAuthenticator.xml
@@ -118,9 +118,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
       </type>
     </element>
-    <element id="LegalAuthenticator.signatureText">
+    <element id="LegalAuthenticator.sdtcSignatureText">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="signatureText"/>
       </extension>
       <path value="LegalAuthenticator.signatureText"/>
       <min value="0"/>

--- a/input/resources/ManufacturedProduct.xml
+++ b/input/resources/ManufacturedProduct.xml
@@ -60,7 +60,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="ManufacturedProduct.identifiedBy"/>
+      <path value="ManufacturedProduct.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/ManufacturedProduct.xml
+++ b/input/resources/ManufacturedProduct.xml
@@ -53,9 +53,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="ManufacturedProduct.identifiedBy">
+    <element id="ManufacturedProduct.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="ManufacturedProduct.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/OrganizationPartOf.xml
+++ b/input/resources/OrganizationPartOf.xml
@@ -53,9 +53,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="OrganizationPartOf.identifiedBy">
+    <element id="OrganizationPartOf.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="OrganizationPartOf.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/OrganizationPartOf.xml
+++ b/input/resources/OrganizationPartOf.xml
@@ -60,7 +60,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="OrganizationPartOf.identifiedBy"/>
+      <path value="OrganizationPartOf.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/ParticipantRole.xml
+++ b/input/resources/ParticipantRole.xml
@@ -53,9 +53,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="ParticipantRole.identifiedBy">
+    <element id="ParticipantRole.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="ParticipantRole.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/ParticipantRole.xml
+++ b/input/resources/ParticipantRole.xml
@@ -60,7 +60,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="ParticipantRole.identifiedBy"/>
+      <path value="ParticipantRole.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/Patient.xml
+++ b/input/resources/Patient.xml
@@ -217,7 +217,7 @@
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
-        <valueString value=""/>
+        <valueString value="raceCode"/>
       </extension>
       <path value="Patient.sdtcRaceCode"/>
       <min value="0"/>

--- a/input/resources/Patient.xml
+++ b/input/resources/Patient.xml
@@ -93,7 +93,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="desc"/>
       </extension>
-      <path value="Patient.desc"/>
+      <path value="Patient.sdtcDesc"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -127,7 +127,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="deceasedInd"/>
       </extension>
-      <path value="Patient.deceasedInd"/>
+      <path value="Patient.sdtcDeceasedInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -141,7 +141,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="deceasedTime"/>
       </extension>
-      <path value="Patient.deceasedTime"/>
+      <path value="Patient.sdtcDeceasedTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -155,7 +155,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="multipleBirthInd"/>
       </extension>
-      <path value="Patient.multipleBirthInd"/>
+      <path value="Patient.sdtcMultipleBirthInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -169,7 +169,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="multipleBirthOrderNumber"/>
       </extension>
-      <path value="Patient.multipleBirthOrderNumber"/>
+      <path value="Patient.sdtcMultipleBirthOrderNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Patient.xml
+++ b/input/resources/Patient.xml
@@ -86,9 +86,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
       </type>
     </element>
-    <element id="Patient.desc">
+    <element id="Patient.sdtcDesc">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="desc"/>
       </extension>
       <path value="Patient.desc"/>
       <min value="0"/>
@@ -117,48 +120,56 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
       </type>
     </element>
-    <element id="Patient.deceasedInd">
+    <element id="Patient.sdtcDeceasedInd">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="deceasedInd"/>
+      </extension>
       <path value="Patient.deceasedInd"/>
-      <short value="sdtc:deceasedInd" />
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/BL"/>
       </type>
     </element>
-    <element id="Patient.deceasedTime">
+    <element id="Patient.sdtcDeceasedTime">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="deceasedTime"/>
+      </extension>
       <path value="Patient.deceasedTime"/>
-      <short value="sdtc:deceasedTime" />
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
       </type>
     </element>
-    <element id="Patient.multipleBirthInd">
+    <element id="Patient.sdtcMultipleBirthInd">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="multipleBirthInd"/>
+      </extension>
       <path value="Patient.multipleBirthInd"/>
-      <short value="sdtc:multipleBirthInd" />
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/BL"/>
       </type>
     </element>
-    <element id="Patient.multipleBirthOrderNumber">
+    <element id="Patient.sdtcMultipleBirthOrderNumber">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="multipleBirthOrderNumber"/>
+      </extension>
       <path value="Patient.multipleBirthOrderNumber"/>
-      <short value="sdtc:multipleBirthOrderNumber" />
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -205,13 +216,12 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
-	  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
-		<valueString value="raceCode"/>
-	  </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value=""/>
+      </extension>
       <path value="Patient.sdtcRaceCode"/>
       <min value="0"/>
       <max value="*"/>
-      <short value="sdtc:RaceCode" />
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
       </type>
@@ -236,10 +246,12 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="ethnicGroupCode"/>
+      </extension>
       <path value="Patient.sdtcEthnicGroupCode"/>
       <min value="0"/>
       <max value="1"/>
-      <short value="sdtc:ethnicGroupCode" />
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
       </type>

--- a/input/resources/PatientRole.xml
+++ b/input/resources/PatientRole.xml
@@ -60,9 +60,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="PatientRole.identifiedBy">
+    <element id="PatientRole.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="PatientRole.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/PatientRole.xml
+++ b/input/resources/PatientRole.xml
@@ -67,7 +67,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="PatientRole.identifiedBy"/>
+      <path value="PatientRole.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/Person.xml
+++ b/input/resources/Person.xml
@@ -78,9 +78,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
       </type>
     </element>
-    <element id="Person.asPatientRelationship">
+    <element id="Person.sdtcAsPatientRelationship">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="asPatientRelationship"/>
       </extension>
       <path value="Person.asPatientRelationship"/>
       <min value="0"/>

--- a/input/resources/Person.xml
+++ b/input/resources/Person.xml
@@ -85,7 +85,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="asPatientRelationship"/>
       </extension>
-      <path value="Person.asPatientRelationship"/>
+      <path value="Person.sdtcAsPatientRelationship"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/SpecimenRole.xml
+++ b/input/resources/SpecimenRole.xml
@@ -60,7 +60,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="identifiedBy"/>
       </extension>
-      <path value="SpecimenRole.identifiedBy"/>
+      <path value="SpecimenRole.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/SpecimenRole.xml
+++ b/input/resources/SpecimenRole.xml
@@ -53,9 +53,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="SpecimenRole.identifiedBy">
+    <element id="SpecimenRole.sdtcIdentifiedBy">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="identifiedBy"/>
       </extension>
       <path value="SpecimenRole.identifiedBy"/>
       <min value="0"/>

--- a/input/resources/SubjectPerson.xml
+++ b/input/resources/SubjectPerson.xml
@@ -77,9 +77,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
       </type>
     </element>
-    <element id="SubjectPerson.desc">
+    <element id="SubjectPerson.sdtcDesc">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="desc"/>
       </extension>
       <path value="SubjectPerson.desc"/>
       <min value="0"/>
@@ -108,9 +111,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
       </type>
     </element>
-    <element id="SubjectPerson.deceasedInd">
+    <element id="SubjectPerson.sdtcDeceasedInd">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="deceasedInd"/>
       </extension>
       <path value="SubjectPerson.deceasedInd"/>
       <min value="0"/>
@@ -119,9 +125,12 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/BL"/>
       </type>
     </element>
-    <element id="SubjectPerson.deceasedTime">
+    <element id="SubjectPerson.sdtcDeceasedTime">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="deceasedTime"/>
       </extension>
       <path value="SubjectPerson.deceasedTime"/>
       <min value="0"/>

--- a/input/resources/SubjectPerson.xml
+++ b/input/resources/SubjectPerson.xml
@@ -84,7 +84,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="desc"/>
       </extension>
-      <path value="SubjectPerson.desc"/>
+      <path value="SubjectPerson.sdtcDesc"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -118,7 +118,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="deceasedInd"/>
       </extension>
-      <path value="SubjectPerson.deceasedInd"/>
+      <path value="SubjectPerson.sdtcDeceasedInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -132,7 +132,7 @@
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
         <valueString value="deceasedTime"/>
       </extension>
-      <path value="SubjectPerson.deceasedTime"/>
+      <path value="SubjectPerson.sdtcDeceasedTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>


### PR DESCRIPTION
Adds `sdtc` to the start of every sdtc extension element id and adds the corresponding `xml-name` extensions