### PR TITLE
[DO NOT MERGE] Base a few profiles off of InfrastructureRoot

### DIFF
--- a/input/resources/Act.xml
+++ b/input/resources/Act.xml
@@ -21,7 +21,7 @@
   <kind value="logical"/>
   <abstract value="false"/>
   <type value="Act"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/InfrastructureRoot"/>
   <derivation value="specialization"/>
   <differential>
     <element id="Act">
@@ -45,31 +45,6 @@
       <max value="1"/>
       <type>
         <code value="code"/>
-      </type>
-    </element>
-    <element id="Act.realmCode">
-      <path value="Act.realmCode"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
-      </type>
-    </element>
-    <element id="Act.typeId">
-      <path value="Act.typeId"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
-      </type>
-    </element>
-    <element id="Act.templateId">
-      <path value="Act.templateId"/>
-      <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
     <element id="Act.id">

--- a/input/resources/Authenticator.xml
+++ b/input/resources/Authenticator.xml
@@ -21,28 +21,13 @@
   <kind value="logical"/>
   <abstract value="false"/>
   <type value="Authenticator"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/InfrastructureRoot"/>
   <derivation value="specialization"/>
   <differential>
     <element id="Authenticator">
       <path value="Authenticator"/>
       <min value="1"/>
       <max value="1"/>
-    </element>
-    <element id="Authenticator.nullFlavor">
-      <path value="Authenticator.nullFlavor"/>
-      <representation value="xmlAttr"/>
-      <label value="Exceptional Value Detail"/>
-      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="code"/>
-      </type>
-      <binding>
-        <strength value="required"/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
-      </binding>
     </element>
     <element id="Authenticator.typeCode">
       <path value="Authenticator.typeCode"/>
@@ -53,38 +38,10 @@
         <code value="code"/>
       </type>
       <fixedCode value="AUTHEN"/>
-      
       <binding>
         <strength value="required"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
       </binding>
-    </element>
-    <element id="Authenticator.realmCode">
-      <path value="Authenticator.realmCode"/>
-      <definition value="When valued in an instance, this attribute signals the imposition of realm-specific constraints. The value of this attribute identifies the realm in question"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
-      </type>
-    </element>
-    <element id="Authenticator.typeId">
-      <path value="Authenticator.typeId"/>
-      <definition value="When valued in an instance, this attribute signals the imposition of constraints defined in an HL7-specified message type. This might be a common type (also known as CMET in the messaging communication environment), or content included within a wrapper. The value of this attribute provides a unique identifier for the type in question."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
-      </type>
-    </element>
-    <element id="Authenticator.templateId">
-      <path value="Authenticator.templateId"/>
-      <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
-      </type>
     </element>
     <element id="Authenticator.time">
       <path value="Authenticator.time"/>

--- a/input/resources/Author.xml
+++ b/input/resources/Author.xml
@@ -21,28 +21,13 @@
   <kind value="logical"/>
   <abstract value="false"/>
   <type value="Author"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+  <baseDefinition value="http://hl7.org/fhir/cda/StructureDefinition/InfrastructureRoot"/>
   <derivation value="specialization"/>
   <differential>
     <element id="Author">
       <path value="Author"/>
       <min value="1"/>
       <max value="1"/>
-    </element>
-    <element id="Author.nullFlavor">
-      <path value="Author.nullFlavor"/>
-      <representation value="xmlAttr"/>
-      <label value="Exceptional Value Detail"/>
-      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="code"/>
-      </type>
-      <binding>
-        <strength value="required"/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
-      </binding>
     </element>
     <element id="Author.typeCode">
       <path value="Author.typeCode"/>
@@ -73,33 +58,6 @@
         <strength value="required"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-ContextControl"/>
       </binding>
-    </element>
-    <element id="Author.realmCode">
-      <path value="Author.realmCode"/>
-      <definition value="When valued in an instance, this attribute signals the imposition of realm-specific constraints. The value of this attribute identifies the realm in question"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
-      </type>
-    </element>
-    <element id="Author.typeId">
-      <path value="Author.typeId"/>
-      <definition value="When valued in an instance, this attribute signals the imposition of constraints defined in an HL7-specified message type. This might be a common type (also known as CMET in the messaging communication environment), or content included within a wrapper. The value of this attribute provides a unique identifier for the type in question."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
-      </type>
-    </element>
-    <element id="Author.templateId">
-      <path value="Author.templateId"/>
-      <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
-      </type>
     </element>
     <element id="Author.functionCode">
       <path value="Author.functionCode"/>

--- a/input/resources/InfrastructureRoot.xml
+++ b/input/resources/InfrastructureRoot.xml
@@ -13,7 +13,7 @@
     <valueUri value="urn:hl7-org:v3"/>
   </extension>
   <url value="http://hl7.org/fhir/cda/StructureDefinition/InfrastructureRoot"/>
-  <name value="Base Type for all classes in the CDA structure"/>
+  <name value="InfrastructureRoot"/>
   <title value="InfrastructureRoot"/>
   <status value="active"/>
   <experimental value="false"/>


### PR DESCRIPTION
Proof-of-concept to base all appropriate profiles on InfrastructureRoot rather than re-defining `nullFlavor`, `realmCode`, `typeId`, and `templateId` on every class that needs them.

This causes the elements to not appear on the Differential table, but they do appear on the Snapshot table (albeit, in a somewhat mixed order of attributes / elements)

| Before      | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/6674267/119878408-b2228500-beef-11eb-84bf-e10bb9e71d59.png)      | ![image](https://user-images.githubusercontent.com/6674267/119878451-bd75b080-beef-11eb-9788-e3bbfa7cdbd5.png)       |
| ![image](https://user-images.githubusercontent.com/6674267/119878479-c797af00-beef-11eb-991d-a899d15abcb0.png)   | ![image](https://user-images.githubusercontent.com/6674267/119878508-d41c0780-beef-11eb-9f0e-b42ecb49b5d0.png)        |


**TODO - Figure out how the `Elements defined in ancestors` logic works on FHIR resources; see if it can be replicated in profiles**
e.g.: 
![image](https://user-images.githubusercontent.com/6674267/119878790-29581900-bef0-11eb-94d4-28a4508baa98.png)

**TODO - if approved, apply to all profiles containing these 4 fields after verifying the type and cardinality matches**