### PR TITLE
Adding IHE Lab, IHE Pharm and sdtc extensions to the CDA Model

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,5 +1,5 @@
 [IG]
-ig = input\hl7.fhir.cda.xml
+ig = input\hl7.cda.uv.core.xml
 template = hl7.cda.template#current
 usage-stats-opt-out = false
 copyrightyear = 2019+

--- a/input/hl7.cda.uv.core.xml
+++ b/input/hl7.cda.uv.core.xml
@@ -1,6 +1,6 @@
 <ImplementationGuide xmlns="http://hl7.org/fhir">
-	<id value="hl7.fhir.cda"/>
-	<url value="http://hl7.org/fhir/cda/ImplementationGuide/cda-ig"/>
+	<id value="hl7.cda.uv.core"/>
+	<url value="http://hl7.org/cda/stds/core/ImplementationGuide/hl7.cda.uv.core"/>
 	<version value="2.1.0-draft1" />
 	<name value="ClinicalDocumentArchitectureV201" />
 	<title value="Clinical Document Architecture V2.0.1" />
@@ -18,8 +18,8 @@
       <value value="cgp@lists.HL7.org"/>
     </telecom>
   </contact>
-	<packageId value="hl7.fhir.cda" />
-	<fhirVersion value="5.0.0-ballot" />
+	<packageId value="hl7.cda.uv.core" />
+	<fhirVersion value="5.0.0-snapshot3" />
 	<definition>
 		<resource>
 			<reference>
@@ -323,6 +323,16 @@
 		</resource>
 		<resource>
 			<reference>
+				<reference value="StructureDefinition/LabCriterion" />
+			</reference>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/LabPrecondition" />
+			</reference>
+		</resource>
+		<resource>
+			<reference>
 				<reference value="StructureDefinition/LabeledDrug" />
 			</reference>
 		</resource>
@@ -434,6 +444,41 @@
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Person" />
+			</reference>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/PharmContent" />
+			</reference>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/PharmIngredient" />
+			</reference>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/PharmMedicineClass" />
+			</reference>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/PharmPackagedMedicine" />
+			</reference>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/PharmSpecializedKind" />
+			</reference>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/PharmSubstance" />
+			</reference>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/PharmSuperContent" />
 			</reference>
 		</resource>
 		<resource>

--- a/input/resources/ClinicalDocument.xml
+++ b/input/resources/ClinicalDocument.xml
@@ -118,6 +118,20 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
       </type>
     </element>
+    <element id="ClinicalDocument.statusCode">
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:hl7-org:sdtc"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="statusCode"/>
+      </extension>
+      <path value="ClinicalDocument.statusCode"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
+      </type>
+    </element>
     <element id="ClinicalDocument.effectiveTime">
       <path value="ClinicalDocument.effectiveTime"/>
       <min value="1"/>

--- a/input/resources/LabCriterion.xml
+++ b/input/resources/LabCriterion.xml
@@ -1,29 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="ObservationRange"/>
+  <id value="LabCriterion"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
-    <valueUri value="urn:hl7-org:v3"/>
+    <valueUri value="urn:oid:1.3.6.1.4.1.19376.1.3.2"/>
   </extension>
-  <url value="http://hl7.org/fhir/cda/StructureDefinition/ObservationRange"/>
-  <name value="CDAR2.ObservationRange"/>
-  <title value="ObservationRange (CDA Class)"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="LabCriterion"/>
+  </extension>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/LabCriterion"/>
+  <name value="CDAR2.LabCriterion"/>
+  <title value="LabCriterion (CDA Class)"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
-  <description value="ObservationRange (CDA Class)"/>
+  <description value="IHE Lab extension, [see confluence](https://confluence.hl7.org/display/SD/CDA+Extensions)"/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="ObservationRange"/>
+  <type value="LabCriterion"/>
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="ObservationRange">
-      <path value="ObservationRange"/>
+    <element id="LabCriterion">
+      <path value="LabCriterion"/>
       <min value="1"/>
       <max value="1"/>
     </element>
-    <element id="ObservationRange.classCode">
-      <path value="ObservationRange.classCode"/>
+    <element id="LabCriterion.nullFlavor">
+      <path value="LabCriterion.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
+    <element id="LabCriterion.classCode">
+      <path value="LabCriterion.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -31,14 +49,14 @@
         <code value="code"/>
       </type>
       <defaultValueCode value="OBS"/>
-      
+
       <binding>
         <strength value="required"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActClassObservation"/>
       </binding>
     </element>
-    <element id="ObservationRange.moodCode">
-      <path value="ObservationRange.moodCode"/>
+    <element id="LabCriterion.moodCode">
+      <path value="LabCriterion.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -47,14 +65,14 @@
       </type>
       <defaultValueCode value="EVN.CRT"/>
       <fixedCode value="EVN.CRT"/>
-      
+
       <binding>
         <strength value="required"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActMoodPredicate"/>
       </binding>
     </element>
-    <element id="ObservationRange.templateId">
-      <path value="ObservationRange.templateId"/>
+    <element id="LabCriterion.templateId">
+      <path value="LabCriterion.templateId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -62,28 +80,28 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
       </type>
     </element>
-    <element id="ObservationRange.code">
-      <path value="ObservationRange.code"/>
+    <element id="LabCriterion.code">
+      <path value="LabCriterion.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CD"/>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
       </type>
       <binding>
         <strength value="extensible"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
       </binding>
     </element>
-    <element id="ObservationRange.text">
-      <path value="ObservationRange.text"/>
+    <element id="LabCriterion.text">
+      <path value="LabCriterion.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ED"/>
       </type>
     </element>
-    <element id="ObservationRange.value">
-      <path value="ObservationRange.value"/>
+    <element id="LabCriterion.value">
+      <path value="LabCriterion.value"/>
       <representation value="typeAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -149,29 +167,6 @@
       </type>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/SXPR-TS"/>
-      </type>
-    </element>
-    <element id="ObservationRange.interpretationCode">
-      <path value="ObservationRange.interpretationCode"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
-      </type>
-      <binding>
-        <strength value="required"/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ObservationInterpretation"/>
-      </binding>
-    </element>
-    <element id="ObservationRange.precondition">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
-        <valueUri value="urn:oid:1.3.6.1.4.1.19376.1.3.2"/>
-      </extension>
-      <path value="ObservationRange.precondition"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="http://hl7.org/fhir/cda/StructureDefinition/LabPrecondition"/>
       </type>
     </element>
   </differential>

--- a/input/resources/LabPrecondition.xml
+++ b/input/resources/LabPrecondition.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="LabPrecondition"/>
+   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+      <valueUri value="urn:oid:1.3.6.1.4.1.19376.1.3.2"/>
+   </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="LabPrecondition"/>
+  </extension>
+  <text>
+  <status value="generated"/>
+  <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>The precondition class, derived from the ActRelationship class, is used along with the LabPrecondition class to express a condition that must hold true before some over activity occurs.</p>
+  </div>
+  </text>
+  <url value="http://hl7.org/fhir/cda/StructureDefinition/LabPrecondition"/>
+  <name value="CDAR2.LabPrecondition"/>
+  <title value="LabPrecondition (CDA Class)"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="IHE Lab extension, [see confluence](https://confluence.hl7.org/display/SD/CDA+Extensions)"/>
+  <kind value="logical"/>
+  <abstract value="false"/>
+  <type value="LabPrecondition"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+  <derivation value="specialization"/>
+  <differential>
+    <element id="LabPrecondition">
+      <path value="LabPrecondition"/>
+      <min value="1"/>
+      <max value="1"/>
+    </element>
+    <element id="LabPrecondition.nullFlavor">
+      <path value="LabPrecondition.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
+    <element id="LabPrecondition.typeCode">
+      <path value="LabPrecondition.typeCode"/>
+      <representation value="xmlAttr"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActRelationshipType"/>
+      </binding>
+    </element>
+    <element id="LabPrecondition.realmCode">
+      <path value="LabPrecondition.realmCode"/>
+      <definition value="When valued in an instance, this attribute signals the imposition of realm-specific constraints. The value of this attribute identifies the realm in question"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
+      </type>
+    </element>
+    <element id="LabPrecondition.typeId">
+      <path value="LabPrecondition.typeId"/>
+      <definition value="When valued in an instance, this attribute signals the imposition of constraints defined in an HL7-specified message type. This might be a common type (also known as CMET in the messaging communication environment), or content included within a wrapper. The value of this attribute provides a unique identifier for the type in question."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
+      </type>
+    </element>
+    <element id="LabPrecondition.templateId">
+      <path value="LabPrecondition.templateId"/>
+      <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/II"/>
+      </type>
+    </element>
+    <element id="LabPrecondition.criterion">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:oid:1.3.6.1.4.1.19376.1.3.2"/>
+      </extension>
+      <path value="LabPrecondition.criterion"/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/LabCriterion"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/Material.xml
+++ b/input/resources/Material.xml
@@ -41,7 +41,6 @@
       </type>
       <defaultValueCode value="MMAT"/>
       <fixedCode value="MMAT"/>
-      
       <binding>
         <strength value="required"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityClassManufacturedMaterial"/>
@@ -57,7 +56,6 @@
       </type>
       <defaultValueCode value="KIND"/>
       <fixedCode value="KIND"/>
-      
       <binding>
         <strength value="required"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityDeterminerDetermined"/>
@@ -107,12 +105,67 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
       </type>
     </element>
+    <element id="Material.formCode">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:ihe:pharm"/>
+      </extension>
+      <path value="Material.formCode"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
+      </type>
+    </element>
     <element id="Material.lotNumberText">
       <path value="Material.lotNumberText"/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+      </type>
+    </element>
+    <element id="Material.expirationTime">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:ihe:pharm"/>
+      </extension>
+      <path value="Material.expirationTime"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/IVL-TS"/>
+      </type>
+    </element>
+    <element id="Material.asContent">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:ihe:pharm"/>
+      </extension>
+      <path value="Material.asContent"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PharmContent"/>
+      </type>
+    </element>
+    <element id="Material.asSpecializedKind">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:ihe:pharm"/>
+      </extension>
+      <path value="Material.asSpecializedKind"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PharmSpecializedKind"/>
+      </type>
+    </element>
+    <element id="Material.ingredient">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:ihe:pharm"/>
+      </extension>
+      <path value="Material.ingredient"/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/PharmIngredient"/>
       </type>
     </element>
   </differential>

--- a/input/resources/Person.xml
+++ b/input/resources/Person.xml
@@ -78,7 +78,15 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
       </type>
     </element>
-    <element id="Person.sdtcAsPatientRelationship">
+    <element id="Person.birthTime">
+      <path value="Person.birthTime"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/TS"/>
+      </type>
+    </element>
+    <element id="Person.asPatientRelationship">
       <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
         <valueUri value="urn:hl7-org:sdtc"/>
       </extension>

--- a/input/resources/PharmContent.xml
+++ b/input/resources/PharmContent.xml
@@ -1,0 +1,48 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+   <id value="PharmContent"/>
+   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+      <valueUri value="urn:ihe:pharm"/>
+   </extension>
+   <url value="http://hl7.org/fhir/cda/StructureDefinition/PharmContent"/>
+   <name value="CDAR2.PharmContent"/>
+   <title value="PharmContent (CDA Pharm Class)"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="HL7"/>
+   <description value="IHE PHARM extension, [see confluence](https://confluence.hl7.org/display/SD/CDA+Extensions)"/>
+   <kind value="logical"/>
+   <abstract value="false"/>
+   <type value="PharmContent"/>
+   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+   <derivation value="specialization"/>
+   <differential>
+      <element id="PharmContent">
+         <path value="PharmContent"/>
+         <min value="1"/>
+         <max value="1"/>
+      </element>
+      <element id="PharmContent.classCode">
+         <path value="PharmContent.classCode"/>
+         <representation value="xmlAttr"/>
+         <min value="1"/>
+         <max value="1"/>
+         <type>
+            <code value="code"/>
+         </type>
+         <defaultValueCode value="CONT"/>
+         <fixedCode value="CONT"/>
+         <mustSupport value="true"/>
+      </element>
+     <element id="PharmContent.containerPackagedMedicine">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>     
+         <path value="PharmContent.containerPackagedMedicine"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/PharmPackagedMedicine"/>
+         </type>
+      </element>      
+   </differential>
+</StructureDefinition>

--- a/input/resources/PharmIngredient.xml
+++ b/input/resources/PharmIngredient.xml
@@ -1,0 +1,59 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+   <id value="PharmIngredient"/>
+   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+      <valueUri value="urn:ihe:pharm"/>
+   </extension>
+   <url value="http://hl7.org/fhir/cda/StructureDefinition/PharmIngredient"/>
+   <name value="CDAR2.PharmIngredient"/>
+   <title value="PharmIngredient (CDA Pharm Class)"/>
+   <description value="IHE PHARM extension, [see confluence](https://confluence.hl7.org/display/SD/CDA+Extensions)"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="HL7"/>
+   <kind value="logical"/>
+   <abstract value="false"/>
+   <type value="PharmIngredient"/>
+   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+   <derivation value="specialization"/>
+   <differential>
+      <element id="PharmIngredient">
+         <path value="PharmIngredient"/>
+         <min value="1"/>
+         <max value="1"/>
+      </element>
+      <element id="PharmIngredient.classCode">
+         <path value="PharmIngredient.classCode"/>
+         <representation value="xmlAttr"/>
+         <min value="1"/>
+         <max value="1"/>
+         <type>
+            <code value="code"/>
+         </type>
+         <defaultValueCode value="ACTI"/>
+         <fixedCode value="ACTI"/>
+         <mustSupport value="true"/>
+      </element>
+      <element id="PharmIngredient.quantity">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmIngredient.quantity"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/RTO-PQ-PQ"/>
+         </type>
+      </element>
+         <element id="PharmIngredient.ingredient">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>     
+         <path value="PharmIngredient.ingredient"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/PharmSubstance"/>
+         </type>
+      </element>      
+   </differential>
+</StructureDefinition>

--- a/input/resources/PharmMedicineClass.xml
+++ b/input/resources/PharmMedicineClass.xml
@@ -1,0 +1,59 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+   <id value="PharmMedicineClass"/>
+   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+      <valueUri value="urn:ihe:pharm"/>
+   </extension>
+   <url value="http://hl7.org/fhir/cda/StructureDefinition/PharmMedicineClass"/>
+   <name value="CDAR2.PharmMedicineClass"/>
+   <title value="PharmMedicineClass (CDA Pharm Class)"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="HL7"/>
+   <description value="IHE PHARM extension, [see confluence](https://confluence.hl7.org/display/SD/CDA+Extensions)"/>
+   <kind value="logical"/>
+   <abstract value="false"/>
+   <type value="PharmMedicineClass"/>
+   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+   <derivation value="specialization"/>
+   <differential>
+      <element id="PharmMedicineClass">
+         <path value="PharmMedicineClass"/>
+         <min value="1"/>
+         <max value="1"/>
+      </element>
+      <element id="PharmMedicineClass.classCode">
+         <path value="PharmMedicineClass.classCode"/>
+         <representation value="xmlAttr"/>
+         <min value="1"/>
+         <max value="1"/>
+         <type>
+            <code value="code"/>
+         </type>
+         <defaultValueCode value="MMAT"/>
+         <fixedCode value="MMAT"/>
+         <mustSupport value="true"/>
+      </element>
+      <element id="PharmMedicineClass.code">
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmMedicineClass.code"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
+         </type>
+      </element>
+      <element id="PharmMedicineClass.name">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmMedicineClass.name"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
+         </type>
+      </element>
+   </differential>
+</StructureDefinition>

--- a/input/resources/PharmPackagedMedicine.xml
+++ b/input/resources/PharmPackagedMedicine.xml
@@ -1,0 +1,115 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+   <id value="PharmPackagedMedicine"/>
+   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+      <valueUri value="urn:ihe:pharm"/>
+   </extension>
+   <url value="http://hl7.org/fhir/cda/StructureDefinition/PharmPackagedMedicine"/>
+   <name value="CDAR2.PharmPackagedMedicine"/>
+   <title value="PharmPackagedMedicine (CDA Pharm Class)"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="HL7"/>
+   <description value="IHE PHARM extension, [see confluence](https://confluence.hl7.org/display/SD/CDA+Extensions)"/>
+   <kind value="logical"/>
+   <abstract value="false"/>
+   <type value="PharmPackagedMedicine"/>
+   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+   <derivation value="specialization"/>
+   <differential>
+      <element id="PharmPackagedMedicine">
+         <path value="PharmPackagedMedicine"/>
+         <min value="1"/>
+         <max value="1"/>
+      </element>
+      <element id="PharmPackagedMedicine.classCode">
+         <path value="PharmPackagedMedicine.classCode"/>
+         <representation value="xmlAttr"/>
+         <min value="1"/>
+         <max value="1"/>
+         <type>
+            <code value="code"/>
+         </type>
+         <defaultValueCode value="CONT"/>
+         <fixedCode value="CONT"/>
+         <mustSupport value="true"/>
+      </element>
+      <element id="PharmPackagedMedicine.determinerCode">
+         <path value="PharmPackagedMedicine.determinerCode"/>
+         <representation value="xmlAttr"/>
+         <min value="1"/>
+         <max value="1"/>
+         <type>
+            <code value="code"/>
+         </type>
+         <defaultValueCode value="INSTANCE"/>
+         <fixedCode value="INSTANCE"/>
+         <mustSupport value="true"/>
+      </element>
+      <element id="PharmPackagedMedicine.code">
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmPackagedMedicine.code"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
+         </type>
+      </element>
+      <element id="PharmPackagedMedicine.name">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmPackagedMedicine.name"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
+         </type>
+      </element>
+      <element id="PharmPackagedMedicine.formCode">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmPackagedMedicine.formCode"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
+         </type>
+      </element>
+      <element id="PharmPackagedMedicine.lotNumberText">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmPackagedMedicine.lotNumberText"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/ST"/>
+         </type>
+      </element>
+      <element id="PharmPackagedMedicine.capacityQuantity">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmPackagedMedicine.capacityQuantity"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/PQ"/>
+         </type>
+      </element>
+      <element id="PharmPackagedMedicine.asSuperContent">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmPackagedMedicine.asSuperContent"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/PharmSuperContent"/>
+         </type>
+      </element>      
+   </differential>
+</StructureDefinition>

--- a/input/resources/PharmSpecializedKind.xml
+++ b/input/resources/PharmSpecializedKind.xml
@@ -1,0 +1,48 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+   <id value="PharmSpecializedKind"/>
+   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+      <valueUri value="urn:ihe:pharm"/>
+   </extension>
+   <url value="http://hl7.org/fhir/cda/StructureDefinition/PharmSpecializedKind"/>
+   <name value="CDAR2.PharmSpecializedKind"/>
+   <title value="PharmSpecializedKind (CDA Pharm Class)"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="HL7"/>
+   <description value="IHE PHARM extension, [see confluence](https://confluence.hl7.org/display/SD/CDA+Extensions)"/>
+   <kind value="logical"/>
+   <abstract value="false"/>
+   <type value="PharmSpecializedKind"/>
+   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+   <derivation value="specialization"/>
+   <differential>
+      <element id="PharmSpecializedKind">
+         <path value="PharmSpecializedKind"/>
+         <min value="1"/>
+         <max value="1"/>
+      </element>
+      <element id="PharmSpecializedKind.classCode">
+         <path value="PharmSpecializedKind.classCode"/>
+         <representation value="xmlAttr"/>
+         <min value="1"/>
+         <max value="1"/>
+         <type>
+            <code value="code"/>
+         </type>
+         <defaultValueCode value="GRIC"/>
+         <fixedCode value="GRIC"/>
+         <mustSupport value="true"/>
+      </element>
+     <element id="PharmSpecializedKind.generalizedMedicineClass">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>     
+         <path value="PharmSpecializedKind.generalizedMedicineClass"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/PharmMedicineClass"/>
+         </type>
+      </element>      
+   </differential>
+</StructureDefinition>

--- a/input/resources/PharmSubstance.xml
+++ b/input/resources/PharmSubstance.xml
@@ -1,0 +1,71 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+   <id value="PharmSubstance"/>
+   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+      <valueUri value="urn:ihe:pharm"/>
+   </extension>
+   <url value="http://hl7.org/fhir/cda/StructureDefinition/PharmSubstance"/>
+   <name value="CDAR2.PharmSubstance"/>
+   <title value="PharmSubstance (CDA Pharm Class)"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="HL7"/>
+   <description value="IHE PHARM extension, [see confluence](https://confluence.hl7.org/display/SD/CDA+Extensions)"/>
+   <kind value="logical"/>
+   <abstract value="false"/>
+   <type value="PharmSubstance"/>
+   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+   <derivation value="specialization"/>
+   <differential>
+      <element id="PharmSubstance">
+         <path value="PharmSubstance"/>
+         <min value="1"/>
+         <max value="1"/>
+      </element>
+      <element id="PharmSubstance.classCode">
+         <path value="PharmSubstance.classCode"/>
+         <representation value="xmlAttr"/>
+         <min value="1"/>
+         <max value="1"/>
+         <type>
+            <code value="code"/>
+         </type>
+         <defaultValueCode value="MMAT"/>
+         <fixedCode value="MMAT"/>
+         <mustSupport value="true"/>
+      </element>
+      <element id="PharmSubstance.determinerCode">
+         <path value="PharmSubstance.determinerCode"/>
+         <representation value="xmlAttr"/>
+         <min value="1"/>
+         <max value="1"/>
+         <type>
+            <code value="code"/>
+         </type>
+         <defaultValueCode value="KIND"/>
+         <fixedCode value="KIND"/>
+         <mustSupport value="true"/>
+      </element>
+      <element id="PharmSubstance.code">
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmSubstance.code"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
+         </type>
+      </element>
+      <element id="PharmSubstance.name">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>
+         <path value="PharmSubstance.name"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/EN"/>
+         </type>
+      </element>
+   </differential>
+</StructureDefinition>

--- a/input/resources/PharmSuperContent.xml
+++ b/input/resources/PharmSuperContent.xml
@@ -1,0 +1,36 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+   <id value="PharmSuperContent"/>
+   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+      <valueUri value="urn:ihe:pharm"/>
+   </extension>
+   <url value="http://hl7.org/fhir/cda/StructureDefinition/PharmSuperContent"/>
+   <name value="CDAR2.PharmSuperContent"/>
+   <title value="PharmSuperContent (CDA Pharm Class)"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="HL7"/>
+   <description value="IHE PHARM extension, [see confluence](https://confluence.hl7.org/display/SD/CDA+Extensions)"/>
+   <kind value="logical"/>
+   <abstract value="false"/>
+   <type value="PharmSuperContent"/>
+   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base"/>
+   <derivation value="specialization"/>
+   <differential>
+      <element id="PharmSuperContent">
+         <path value="PharmSuperContent"/>
+         <min value="1"/>
+         <max value="1"/>
+      </element>
+     <element id="PharmSuperContent.containerPackagedMedicine">
+         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+            <valueUri value="urn:ihe:pharm"/>
+         </extension>     
+         <path value="PharmSuperContent.containerPackagedMedicine"/>
+         <min value="0"/>
+         <max value="1"/>
+         <type>
+            <code value="http://hl7.org/fhir/cda/StructureDefinition/PharmPackagedMedicine"/>
+         </type>
+      </element>      
+   </differential>
+</StructureDefinition>

--- a/input/resources/RTO-PQ-PQ.xml
+++ b/input/resources/RTO-PQ-PQ.xml
@@ -24,6 +24,7 @@
     </element>
     <element id="RTO_PQ_PQ.numerator">
       <path value="RTO_PQ_PQ.numerator"/>
+      <representation value="typeAttr"/>
       <label value="Numerator"/>
       <definition value="The quantity that is being divided in the ratio. The default is the integer number 1 (one.)"/>
       <min value="0"/>
@@ -34,6 +35,7 @@
     </element>
     <element id="RTO_PQ_PQ.denominator">
       <path value="RTO_PQ_PQ.denominator"/>
+      <representation value="typeAttr"/>
       <label value="Denominator"/>
       <definition value="The quantity that devides the numerator in the ratio. The default is the integer number 1 (one.) The denominator must not be zero."/>
       <min value="0"/>

--- a/input/resources/ServiceEvent.xml
+++ b/input/resources/ServiceEvent.xml
@@ -87,6 +87,20 @@
         <code value="http://hl7.org/fhir/cda/StructureDefinition/CE"/>
       </type>
     </element>
+    <element id="ServiceEvent.statusCode">
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+        <valueUri value="urn:oid:1.3.6.1.4.1.19376.1.3.2"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
+        <valueString value="statusCode"/>
+      </extension>
+      <path value="ServiceEvent.statusCode"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="http://hl7.org/fhir/cda/StructureDefinition/CS"/>
+      </type>
+    </element>
     <element id="ServiceEvent.effectiveTime">
       <path value="ServiceEvent.effectiveTime"/>
       <min value="0"/>


### PR DESCRIPTION
This PR adds the following extensions to the CDA-Core:

- [adding sdtc ClinicalDocument.statusCode](https://github.com/HL7/CDA-core-2.0/commit/459e6a6880ef12875793bd7dbdee4f2b7df98e9c)
- [add IHE LAB extensions](https://github.com/HL7/CDA-core-2.0/commit/1b2fa9b283cb7eda3af09319d5778d1d38345aaa)
- [add IHE PHARM extensions](https://github.com/HL7/CDA-core-2.0/commit/8cb9c3cd2160401b3e3626522ebc1d0b7e728f3e)
- [adding typeAttr to RTO-PQ-PQ](https://github.com/HL7/CDA-core-2.0/commit/f25ef269736d349a748ef3a669a3f28fc1f84764)
- [adding Person.birthTime](https://github.com/HL7/CDA-core-2.0/commit/09507b51340c167ceffdab4ffcb4d71451f7c11c)
