### PR TITLE
Create primitive-type profiles for all CDA simple types

### DIFF
--- a/CDA-core.xml
+++ b/CDA-core.xml
@@ -119,7 +119,20 @@
 <artifact id="StructureDefinition/TEL" key="StructureDefinition-TEL" name="TEL: TelecommunicationAddress (V3 Data Type)"/>
 <artifact id="StructureDefinition/TN" key="StructureDefinition-TN" name="TN: TrivialName (V3 Data Type)"/>
 <artifact id="StructureDefinition/TS" key="StructureDefinition-TS" name="TS: PointInTime (V3 Data Type)"/>
-<artifact id="StructureDefinition/cs-prim" key="StructureDefinition-cs-prim" name="cs primitive (wrapper for code)"/>
+<artifact id="StructureDefinition/bin" key="StructureDefinition-bin" name="bin: Binary Data"/>
+<artifact id="StructureDefinition/bl-simple" key="StructureDefinition-bl-simple" name="bl: Boolean"/>
+<artifact id="StructureDefinition/bn" key="StructureDefinition-bn" name="bn: BooleanNonNull"/>
+<artifact id="StructureDefinition/cs-simple" key="StructureDefinition-cs-simple" name="cs: Coded Simple Value"/>
+<artifact id="StructureDefinition/int-simple" key="StructureDefinition-int-simple" name="int: Integer Number"/>
+<artifact id="StructureDefinition/oid" key="StructureDefinition-oid" name="oid: ISO Object Identifier"/>
+<artifact id="StructureDefinition/probability" key="StructureDefinition-probability" name="probability: Probability"/>
+<artifact id="StructureDefinition/real-simple" key="StructureDefinition-real-simple" name="real: Real Number"/>
+<artifact id="StructureDefinition/ruid" key="StructureDefinition-ruid" name="ruid: HL7 Reserved Identifier Scheme"/>
+<artifact id="StructureDefinition/st-simple" key="StructureDefinition-st-simple" name="st: Character String"/>
+<artifact id="StructureDefinition/ts-simple" key="StructureDefinition-ts-simple" name="ts: Point in Time"/>
+<artifact id="StructureDefinition/uid" key="StructureDefinition-uid" name="uid: Unique Identifier String"/>
+<artifact id="StructureDefinition/url" key="StructureDefinition-url" name="url: Universal Resource Locator"/>
+<artifact id="StructureDefinition/uuid" key="StructureDefinition-uuid" name="uuid: DCE Universal Unique Identifier"/>
 <page key="NA" name="(NA)"/>
 <page key="many" name="(many)"/>
 <page key="artifacts" name="Artifacts Summary"/>

--- a/CDA-core.xml
+++ b/CDA-core.xml
@@ -133,6 +133,7 @@
 <artifact id="StructureDefinition/uid" key="StructureDefinition-uid" name="uid: Unique Identifier String"/>
 <artifact id="StructureDefinition/url" key="StructureDefinition-url" name="url: Universal Resource Locator"/>
 <artifact id="StructureDefinition/uuid" key="StructureDefinition-uuid" name="uuid: DCE Universal Unique Identifier"/>
+<artifact id="StructureDefinition/xs-ID" key="StructureDefinition-xs-ID" name="xs:ID"/>
 <page key="NA" name="(NA)"/>
 <page key="many" name="(many)"/>
 <page key="artifacts" name="Artifacts Summary"/>

--- a/input/hl7.cda.uv.core.xml
+++ b/input/hl7.cda.uv.core.xml
@@ -26,575 +26,802 @@
 		<version value="5.2.0"/>
 	</dependsOn>
 	<definition>
+		<grouping id="classes">
+				<name value="CDA Classes"/>
+				<description value="Primary CDA Objects"/>
+		</grouping>
+		<grouping id="datatypes-complex">
+				<name value="V3 Complex Data Types"/>
+				<description value="General-purpose complex types, which are re-usable clusters of elements"/>
+		</grouping>
+		<grouping id="datatypes-simple">
+				<name value="V3 Simple Data Types"/>
+				<description value="Simple / primitive types, which are single XML attributes"/>
+		</grouping>
+		<grouping id="datatypes-xml">
+				<name value="XML Data Types"/>
+				<description value="Other, non-CDA, data types used to support exchange of CDA documents"/>
+		</grouping>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Act" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/AD" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ADXP" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/AlternateIdentification" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ANY" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/AssignedAuthor" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/AssignedCustodian" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/AssignedEntity" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/AssociatedEntity" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Authenticator" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Author" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/AuthoringDevice" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Authorization" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Birthplace" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/BL" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/CD" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/CE" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ClinicalDocument" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
+		<!--
+		<resource>
+			<extension url="http://hl7.org/fhir/StructureDefinition/implementationguide-resource-format">
+					<valueCode value="application/xml"/>
+			</extension>
+			<reference>
+					<reference value="Binary/clinicaldocument-example"/>
+				</reference>
+			<name value="Example CDA document"/>
+			<description value="Example CDA document"/>
+			<isExample value="true"/>
+			<profile value="http://hl7.org/cda/stds/core/StructureDefinition/ClinicalDocument"/>
+	</resource>-->
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/CO" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Component2" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ComponentOf" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Consent" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/CR" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Criterion" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/CS" />
 			</reference>
-		</resource>
-		<resource>
-			<reference>
-				<reference value="StructureDefinition/cs-simple" />
-			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Custodian" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/CustodianOrganization" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/CV" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/DataEnterer" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Device" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/DocumentationOf" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Performer1" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Performer2" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ED" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/EIVL-TS" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/EN" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/EncompassingEncounter" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Encounter" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/EncounterParticipant" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Entity" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ENXP" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ExternalAct" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ExternalDocument" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ExternalObservation" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ExternalProcedure" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Guardian" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/HealthCareFacility" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/IdentifiedBy" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/II" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Informant" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/InformationRecipient" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/InfrastructureRoot" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/InFulfillmentOf" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/INT" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/INT-POS" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/IntendedRecipient" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/IVL-INT" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/IVL-PQ" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/IVL-TS" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/LabeledDrug" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/LanguageCommunication" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/LegalAuthenticator" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/MaintainedEntity" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ManufacturedProduct" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Material" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/MO" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/NonXMLBody" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Observation" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ObservationMedia" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ObservationRange" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ON" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Order" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Organization" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/OrganizationPartOf" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Organizer" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ParentDocument" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Participant1" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Participant2" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ParticipantRole" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Patient" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/PatientRole" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Person" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/PIVL-TS" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Place" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/PlayingEntity" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/PN" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/PQ" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/PQR" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Precondition" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Procedure" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/QTY" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/REAL" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/RecordTarget" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/RegionOfInterest" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/RelatedDocument" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/RelatedEntity" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/RelatedSubject" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/RTO-PQ-PQ" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/SC" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Section" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ServiceEvent" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Specimen" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/SpecimenRole" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/ST" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/StructuredBody" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/SubjectPerson" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/SubstanceAdministration" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/Supply" />
 			</reference>
+			<groupingId value="classes"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/SXCM-TS" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/SXPR-TS" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/TEL" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/TN" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
 		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/TS" />
 			</reference>
+			<groupingId value="datatypes-complex"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/bin" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/bl-simple" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/bn" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/cs-simple" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/int-simple" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/oid" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/probability" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/real-simple" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/ruid" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/st-simple" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/ts-simple" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/uid" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/url" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/uuid" />
+			</reference>
+			<groupingId value="datatypes-simple"/>
+		</resource>
+		<resource>
+			<reference>
+				<reference value="StructureDefinition/xs-ID" />
+			</reference>
+			<groupingId value="datatypes-xml"/>
 		</resource>
 		<page>
 			<sourceUrl value="index.html"/>

--- a/input/hl7.cda.uv.core.xml
+++ b/input/hl7.cda.uv.core.xml
@@ -153,7 +153,7 @@
 		</resource>
 		<resource>
 			<reference>
-				<reference value="StructureDefinition/cs-prim" />
+				<reference value="StructureDefinition/cs-simple" />
 			</reference>
 		</resource>
 		<resource>

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -128,21 +128,20 @@ This FHIR Implementation Guide represents CDA using the FHIR Type Definition Fra
 		<td>
 			<h3>V3 Simple Data Types</h3>
 				<ul>
-					<li><a href="StructureDefinition-bin.html">bin: BinaryData</a></li>
-					<li><a href="StructureDefinition-bin">bin: Binary Data</a></li>
-					<li><a href="StructureDefinition-bl-simple">bl: Boolean</a></li>
-					<li><a href="StructureDefinition-bn">bn: BooleanNonNull</a></li>
-					<li><a href="StructureDefinition-cs-simple">cs: Coded Simple Value</a></li>
-					<li><a href="StructureDefinition-int-simple">int: Integer Number</a></li>
-					<li><a href="StructureDefinition-oid">oid: ISO Object Identifier</a></li>
-					<li><a href="StructureDefinition-probability">probability: Probability</a></li>
-					<li><a href="StructureDefinition-real-simple">real: Real Number</a></li>
-					<li><a href="StructureDefinition-ruid">ruid: HL7 Reserved Identifier Scheme</a></li>
-					<li><a href="StructureDefinition-st-simple">st: Character String</a></li>
-					<li><a href="StructureDefinition-ts-simple">ts: Point in Time</a></li>
-					<li><a href="StructureDefinition-uid">uid: Unique Identifier String</a></li>
-					<li><a href="StructureDefinition-url">url: Universal Resource Locator</a></li>
-					<li><a href="StructureDefinition-uuid">uuid: DCE Universal Unique Identifier</a></li>
+					<li><a href="StructureDefinition-bin.html">bin: Binary Data</a></li>
+					<li><a href="StructureDefinition-bl-simple.html">bl: Boolean</a></li>
+					<li><a href="StructureDefinition-bn.html">bn: BooleanNonNull</a></li>
+					<li><a href="StructureDefinition-cs-simple.html">cs: Coded Simple Value</a></li>
+					<li><a href="StructureDefinition-int-simple.html">int: Integer Number</a></li>
+					<li><a href="StructureDefinition-oid.html">oid: ISO Object Identifier</a></li>
+					<li><a href="StructureDefinition-probability.html">probability: Probability</a></li>
+					<li><a href="StructureDefinition-real-simple.html">real: Real Number</a></li>
+					<li><a href="StructureDefinition-ruid.html">ruid: HL7 Reserved Identifier Scheme</a></li>
+					<li><a href="StructureDefinition-st-simple.html">st: Character String</a></li>
+					<li><a href="StructureDefinition-ts-simple.html">ts: Point in Time</a></li>
+					<li><a href="StructureDefinition-uid.html">uid: Unique Identifier String</a></li>
+					<li><a href="StructureDefinition-url.html">url: Universal Resource Locator</a></li>
+					<li><a href="StructureDefinition-uuid.html">uuid: DCE Universal Unique Identifier</a></li>
 				</ul>
 		</td>
 	</tr>

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -86,7 +86,7 @@ This FHIR Implementation Guide represents CDA using the FHIR Type Definition Fra
 			</ul>
 		</td>
 		<td>
-			<h3>V3 Data Types</h3>
+			<h3>V3 Complex Data Types</h3>
 			<ul>
 				<li><a href="StructureDefinition-AD.html">AD: PostalAddress</a></li>
 				<li><a href="StructureDefinition-ADXP.html">ADXP: CharacterString</a></li>
@@ -124,6 +124,26 @@ This FHIR Implementation Guide represents CDA using the FHIR Type Definition Fra
 				<li><a href="StructureDefinition-TS.html">TS: PointInTime</a></li>
 				<li><a href="StructureDefinition-TN.html">TN: TrivialName</a></li>
 			</ul>
+		</td>
+		<td>
+			<h3>V3 Simple Data Types</h3>
+				<ul>
+					<li><a href="StructureDefinition-bin.html">bin: BinaryData</a></li>
+					<li><a href="StructureDefinition-bin">bin: Binary Data</a></li>
+					<li><a href="StructureDefinition-bl-simple">bl: Boolean</a></li>
+					<li><a href="StructureDefinition-bn">bn: BooleanNonNull</a></li>
+					<li><a href="StructureDefinition-cs-simple">cs: Coded Simple Value</a></li>
+					<li><a href="StructureDefinition-int-simple">int: Integer Number</a></li>
+					<li><a href="StructureDefinition-oid">oid: ISO Object Identifier</a></li>
+					<li><a href="StructureDefinition-probability">probability: Probability</a></li>
+					<li><a href="StructureDefinition-real-simple">real: Real Number</a></li>
+					<li><a href="StructureDefinition-ruid">ruid: HL7 Reserved Identifier Scheme</a></li>
+					<li><a href="StructureDefinition-st-simple">st: Character String</a></li>
+					<li><a href="StructureDefinition-ts-simple">ts: Point in Time</a></li>
+					<li><a href="StructureDefinition-uid">uid: Unique Identifier String</a></li>
+					<li><a href="StructureDefinition-url">url: Universal Resource Locator</a></li>
+					<li><a href="StructureDefinition-uuid">uuid: DCE Universal Unique Identifier</a></li>
+				</ul>
 		</td>
 	</tr>
 	</tbody>

--- a/input/resources/AD.xml
+++ b/input/resources/AD.xml
@@ -67,6 +67,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="AD.use">

--- a/input/resources/AD.xml
+++ b/input/resources/AD.xml
@@ -809,9 +809,9 @@
       <definition value="Textual representation of (part of) the address"/>
       <min value="0"/>
       <max value="1"/>
-      
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
     <element id="AD.useablePeriod[x]">

--- a/input/resources/AD.xml
+++ b/input/resources/AD.xml
@@ -51,6 +51,7 @@
       </base>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -77,6 +78,7 @@
       <max value="*"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="AD.delimiter">
@@ -106,6 +108,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="DEL"/>
     </element>
@@ -136,6 +139,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="CNT"/>
     </element>
@@ -166,6 +170,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="STA"/>
     </element>
@@ -196,6 +201,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="CPA"/>
     </element>
@@ -226,6 +232,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="CTY"/>
     </element>
@@ -256,6 +263,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="ZIP"/>
     </element>
@@ -286,6 +294,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="SAL"/>
     </element>
@@ -316,6 +325,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="BNR"/>
     </element>
@@ -346,6 +356,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="BNN"/>
     </element>
@@ -376,6 +387,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="DIR"/>
     </element>
@@ -406,6 +418,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="STR"/>
     </element>
@@ -436,6 +449,7 @@
       </base>-->
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="STB"/>
     </element>
@@ -462,6 +476,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="STTYP"/>
     </element>
@@ -484,6 +499,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="ADL"/>
     </element>
@@ -506,6 +522,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="UNID"/>
     </element>
@@ -528,6 +545,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="UNIT"/>
     </element>
@@ -550,6 +568,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="CAR"/>
     </element>
@@ -572,6 +591,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="CEN"/>
     </element>
@@ -594,6 +614,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="DAL"/>
     </element>
@@ -616,6 +637,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="DINST"/>
     </element>
@@ -638,6 +660,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="DINSTA"/>
     </element>
@@ -660,6 +683,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="DINSTQ"/>
     </element>
@@ -682,6 +706,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="DMOD"/>
     </element>
@@ -704,6 +729,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="DMODID"/>
     </element>
@@ -726,6 +752,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="BNS"/>
     </element>
@@ -748,6 +775,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="POB"/>
     </element>
@@ -770,6 +798,7 @@
       
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="PRE"/>
     </element>

--- a/input/resources/ADXP.xml
+++ b/input/resources/ADXP.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
   </differential>

--- a/input/resources/ANY.xml
+++ b/input/resources/ANY.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>

--- a/input/resources/Act.xml
+++ b/input/resources/Act.xml
@@ -126,6 +126,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Act.text">
@@ -382,6 +383,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Act.entryRelationship.contextConductionInd">
@@ -392,6 +394,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
     </element>
@@ -412,6 +415,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Act.entryRelationship.seperatableInd">

--- a/input/resources/Act.xml
+++ b/input/resources/Act.xml
@@ -40,6 +40,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="Act.moodCode">
@@ -64,6 +66,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="Act.realmCode">
@@ -199,6 +202,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBJ"/>
       <fixedCode value="SBJ"/>
@@ -215,6 +219,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -289,6 +294,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INF"/>
       <fixedCode value="INF"/>
@@ -305,6 +311,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -364,6 +371,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="Act.entryRelationship.inversionInd">
@@ -513,6 +521,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="Act.reference.seperatableInd">

--- a/input/resources/Act.xml
+++ b/input/resources/Act.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Act">
       <path value="Act"/>
-      <definition value="Element Act"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Act.nullFlavor">
       <path value="Act.nullFlavor"/>
-      <definition value="Element Act.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
       <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
@@ -60,7 +58,6 @@
     </element>
     <element id="Act.moodCode">
       <path value="Act.moodCode"/>
-      <definition value="Element Act.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -71,7 +68,6 @@
     </element>
     <element id="Act.realmCode">
       <path value="Act.realmCode"/>
-      <definition value="Element Act.realmCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -80,7 +76,6 @@
     </element>
     <element id="Act.typeId">
       <path value="Act.typeId"/>
-      <definition value="Element Act.typeId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -98,7 +93,6 @@
     </element>
     <element id="Act.id">
       <path value="Act.id"/>
-      <definition value="Element Act.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -107,7 +101,6 @@
     </element>
     <element id="Act.code">
       <path value="Act.code"/>
-      <definition value="Element Act.code"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -120,7 +113,6 @@
     </element>
     <element id="Act.negationInd">
       <path value="Act.negationInd"/>
-      <definition value="Element Act.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -131,7 +123,6 @@
     </element>
     <element id="Act.text">
       <path value="Act.text"/>
-      <definition value="Element Act.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -140,7 +131,6 @@
     </element>
     <element id="Act.statusCode">
       <path value="Act.statusCode"/>
-      <definition value="Element Act.statusCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -153,7 +143,6 @@
     </element>
     <element id="Act.effectiveTime">
       <path value="Act.effectiveTime"/>
-      <definition value="Element Act.effectiveTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -162,7 +151,6 @@
     </element>
     <element id="Act.priorityCode">
       <path value="Act.priorityCode"/>
-      <definition value="Element Act.priorityCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -175,7 +163,6 @@
     </element>
     <element id="Act.languageCode">
       <path value="Act.languageCode"/>
-      <definition value="Element Act.languageCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -188,7 +175,6 @@
     </element>
     <element id="Act.subject">
       <path value="Act.subject"/>
-      <definition value="Element Act.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -231,7 +217,6 @@
     </element>
     <element id="Act.subject.awarenessCode">
       <path value="Act.subject.awarenessCode"/>
-      <definition value="Element Act.subject.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -244,7 +229,6 @@
     </element>
     <element id="Act.subject.relatedSubject">
       <path value="Act.subject.relatedSubject"/>
-      <definition value="Element Act.subject.relatedSubject"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -253,7 +237,6 @@
     </element>
     <element id="Act.specimen">
       <path value="Act.specimen"/>
-      <definition value="Element Act.specimen"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -262,7 +245,6 @@
     </element>
     <element id="Act.performer">
       <path value="Act.performer"/>
-      <definition value="Element Act.performer"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -271,7 +253,6 @@
     </element>
     <element id="Act.author">
       <path value="Act.author"/>
-      <definition value="Element Act.author"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -280,7 +261,6 @@
     </element>
     <element id="Act.informant">
       <path value="Act.informant"/>
-      <definition value="Element Act.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -323,7 +303,6 @@
     </element>
     <element id="Act.informant.assignedEntity">
       <path value="Act.informant.assignedEntity"/>
-      <definition value="Element Act.informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -332,7 +311,6 @@
     </element>
     <element id="Act.informant.relatedEntity">
       <path value="Act.informant.relatedEntity"/>
-      <definition value="Element Act.informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -341,7 +319,6 @@
     </element>
     <element id="Act.participant">
       <path value="Act.participant"/>
-      <definition value="Element Act.participant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -350,7 +327,6 @@
     </element>
     <element id="Act.entryRelationship">
       <path value="Act.entryRelationship"/>
-      <definition value="Element Act.entryRelationship"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -400,7 +376,6 @@
     </element>
     <element id="Act.entryRelationship.sequenceNumber">
       <path value="Act.entryRelationship.sequenceNumber"/>
-      <definition value="Element Act.entryRelationship.sequenceNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -409,7 +384,6 @@
     </element>
     <element id="Act.entryRelationship.negationInd">
       <path value="Act.entryRelationship.negationInd"/>
-      <definition value="Element Act.entryRelationship.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -420,7 +394,6 @@
     </element>
     <element id="Act.entryRelationship.seperatableInd">
       <path value="Act.entryRelationship.seperatableInd"/>
-      <definition value="Element Act.entryRelationship.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -429,7 +402,6 @@
     </element>
     <element id="Act.entryRelationship.observation">
       <path value="Act.entryRelationship.observation"/>
-      <definition value="Element Act.entryRelationship.observation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -438,7 +410,6 @@
     </element>
     <element id="Act.entryRelationship.regionOfInterest">
       <path value="Act.entryRelationship.regionOfInterest"/>
-      <definition value="Element Act.entryRelationship.regionOfInterest"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -447,7 +418,6 @@
     </element>
     <element id="Act.entryRelationship.observationMedia">
       <path value="Act.entryRelationship.observationMedia"/>
-      <definition value="Element Act.entryRelationship.observationMedia"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -456,7 +426,6 @@
     </element>
     <element id="Act.entryRelationship.substanceAdministration">
       <path value="Act.entryRelationship.substanceAdministration"/>
-      <definition value="Element Act.entryRelationship.substanceAdministration"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -465,7 +434,6 @@
     </element>
     <element id="Act.entryRelationship.supply">
       <path value="Act.entryRelationship.supply"/>
-      <definition value="Element Act.entryRelationship.supply"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -474,7 +442,6 @@
     </element>
     <element id="Act.entryRelationship.procedure">
       <path value="Act.entryRelationship.procedure"/>
-      <definition value="Element Act.entryRelationship.procedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -483,7 +450,6 @@
     </element>
     <element id="Act.entryRelationship.encounter">
       <path value="Act.entryRelationship.encounter"/>
-      <definition value="Element Act.entryRelationship.encounter"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -492,7 +458,6 @@
     </element>
     <element id="Act.entryRelationship.organizer">
       <path value="Act.entryRelationship.organizer"/>
-      <definition value="Element Act.entryRelationship.organizer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -501,7 +466,6 @@
     </element>
     <element id="Act.entryRelationship.act">
       <path value="Act.entryRelationship.act"/>
-      <definition value="Element Act.entryRelationship.act"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -510,7 +474,6 @@
     </element>
     <element id="Act.reference">
       <path value="Act.reference"/>
-      <definition value="Element Act.reference"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -530,7 +493,6 @@
     </element>
     <element id="Act.reference.seperatableInd">
       <path value="Act.reference.seperatableInd"/>
-      <definition value="Element Act.reference.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -539,7 +501,6 @@
     </element>
     <element id="Act.reference.externalAct">
       <path value="Act.reference.externalAct"/>
-      <definition value="Element Act.reference.externalAct"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -548,7 +509,6 @@
     </element>
     <element id="Act.reference.externalObservation">
       <path value="Act.reference.externalObservation"/>
-      <definition value="Element Act.reference.externalObservation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -557,7 +517,6 @@
     </element>
     <element id="Act.reference.externalProcedure">
       <path value="Act.reference.externalProcedure"/>
-      <definition value="Element Act.reference.externalProcedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -566,7 +525,6 @@
     </element>
     <element id="Act.reference.externalDocument">
       <path value="Act.reference.externalDocument"/>
-      <definition value="Element Act.reference.externalDocument"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -575,7 +533,6 @@
     </element>
     <element id="Act.precondition">
       <path value="Act.precondition"/>
-      <definition value="Element Act.precondition"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/AlternateIdentification.xml
+++ b/input/resources/AlternateIdentification.xml
@@ -38,6 +38,7 @@
       <max value="1" />
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="IDENT" />
       <binding>

--- a/input/resources/AlternateIdentification.xml
+++ b/input/resources/AlternateIdentification.xml
@@ -23,7 +23,6 @@
   <differential>
     <element id="AlternateIdentification">
       <path value="AlternateIdentification"/>
-      <definition value="Element AlternateIdentification"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -63,7 +62,6 @@
         <valueUri value="urn:hl7-org:v3"/>
       </extension>
       <path value="AlternateIdentification.code"/>
-      <definition value="Element AlternateIdentification.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -75,7 +73,6 @@
         <valueUri value="urn:hl7-org:v3"/>
       </extension>
       <path value="AlternateIdentification.statusCode"/>
-      <definition value="Element AlternateIdentification.statusCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -91,7 +88,6 @@
         <valueUri value="urn:hl7-org:v3"/>
       </extension>
       <path value="AlternateIdentification.effectiveTime"/>
-      <definition value="Element AlternateIdentification.effectiveTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/AssignedAuthor.xml
+++ b/input/resources/AssignedAuthor.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="AssignedAuthor">
       <path value="AssignedAuthor"/>
-      <definition value="Element AssignedAuthor"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="AssignedAuthor.classCode">
       <path value="AssignedAuthor.classCode"/>
-      <definition value="Element AssignedAuthor.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -57,7 +55,6 @@
     </element>
     <element id="AssignedAuthor.id">
       <path value="AssignedAuthor.id"/>
-      <definition value="Element AssignedAuthor.id"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -72,7 +69,6 @@
         <valueString value="identifiedBy"/>
       </extension>
       <path value="AssignedAuthor.sdtcIdentifiedBy"/>
-      <definition value="Element AssignedAuthor.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -81,7 +77,6 @@
     </element>
     <element id="AssignedAuthor.code">
       <path value="AssignedAuthor.code"/>
-      <definition value="Element AssignedAuthor.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -94,7 +89,6 @@
     </element>
     <element id="AssignedAuthor.addr">
       <path value="AssignedAuthor.addr"/>
-      <definition value="Element AssignedAuthor.addr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -103,7 +97,6 @@
     </element>
     <element id="AssignedAuthor.telecom">
       <path value="AssignedAuthor.telecom"/>
-      <definition value="Element AssignedAuthor.telecom"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -112,7 +105,6 @@
     </element>
     <element id="AssignedAuthor.assignedPerson">
       <path value="AssignedAuthor.assignedPerson"/>
-      <definition value="Element AssignedAuthor.assignedPerson"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -121,7 +113,6 @@
     </element>
     <element id="AssignedAuthor.assignedAuthoringDevice">
       <path value="AssignedAuthor.assignedAuthoringDevice"/>
-      <definition value="Element AssignedAuthor.assignedAuthoringDevice"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -130,7 +121,6 @@
     </element>
     <element id="AssignedAuthor.representedOrganization">
       <path value="AssignedAuthor.representedOrganization"/>
-      <definition value="Element AssignedAuthor.representedOrganization"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/AssignedAuthor.xml
+++ b/input/resources/AssignedAuthor.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ASSIGNED"/>
       <fixedCode value="ASSIGNED"/>

--- a/input/resources/AssignedCustodian.xml
+++ b/input/resources/AssignedCustodian.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="AssignedCustodian">
       <path value="AssignedCustodian"/>
-      <definition value="Element AssignedCustodian"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="AssignedCustodian.classCode">
       <path value="AssignedCustodian.classCode"/>
-      <definition value="Element AssignedCustodian.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -48,7 +46,6 @@
     </element>
     <element id="AssignedCustodian.templateId">
       <path value="AssignedCustodian.templateId"/>
-      <definition value="Element AssignedCustodian.templateId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -58,7 +55,6 @@
     </element>
     <element id="AssignedCustodian.representedCustodianOrganization">
       <path value="AssignedCustodian.representedCustodianOrganization"/>
-      <definition value="Element AssignedCustodian.representedCustodianOrganization"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/AssignedCustodian.xml
+++ b/input/resources/AssignedCustodian.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ASSIGNED"/>
       <fixedCode value="ASSIGNED"/>

--- a/input/resources/AssignedEntity.xml
+++ b/input/resources/AssignedEntity.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="AssignedEntity">
       <path value="AssignedEntity"/>
-      <definition value="Element AssignedEntity"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="AssignedEntity.classCode">
       <path value="AssignedEntity.classCode"/>
-      <definition value="Element AssignedEntity.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -42,7 +40,6 @@
     </element>
     <element id="AssignedEntity.templateId">
       <path value="AssignedEntity.templateId"/>
-      <definition value="Element AssignedEntity.templateId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -52,7 +49,6 @@
     </element>
     <element id="AssignedEntity.id">
       <path value="AssignedEntity.id"/>
-      <definition value="Element AssignedEntity.id"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -76,7 +72,6 @@
     </element>
     <element id="AssignedEntity.code">
       <path value="AssignedEntity.code"/>
-      <definition value="Element AssignedEntity.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -89,7 +84,6 @@
     </element>
     <element id="AssignedEntity.addr">
       <path value="AssignedEntity.addr"/>
-      <definition value="Element AssignedEntity.addr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -98,7 +92,6 @@
     </element>
     <element id="AssignedEntity.telecom">
       <path value="AssignedEntity.telecom"/>
-      <definition value="Element AssignedEntity.telecom"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -107,7 +100,6 @@
     </element>
     <element id="AssignedEntity.assignedPerson">
       <path value="AssignedEntity.assignedPerson"/>
-      <definition value="Element AssignedEntity.assignedPerson"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -116,7 +108,6 @@
     </element>
     <element id="AssignedEntity.representedOrganization">
       <path value="AssignedEntity.representedOrganization"/>
-      <definition value="Element AssignedEntity.representedOrganization"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/AssignedEntity.xml
+++ b/input/resources/AssignedEntity.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ASSIGNED"/>
       <fixedCode value="ASSIGNED"/>

--- a/input/resources/AssociatedEntity.xml
+++ b/input/resources/AssociatedEntity.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>

--- a/input/resources/AssociatedEntity.xml
+++ b/input/resources/AssociatedEntity.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="AssociatedEntity">
       <path value="AssociatedEntity"/>
-      <definition value="Element AssociatedEntity"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="AssociatedEntity.classCode">
       <path value="AssociatedEntity.classCode"/>
-      <definition value="Element AssociatedEntity.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -55,7 +53,6 @@
     </element>
     <element id="AssociatedEntity.id">
       <path value="AssociatedEntity.id"/>
-      <definition value="Element AssociatedEntity.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -78,7 +75,6 @@
     </element>
     <element id="AssociatedEntity.code">
       <path value="AssociatedEntity.code"/>
-      <definition value="Element AssociatedEntity.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -91,7 +87,6 @@
     </element>
     <element id="AssociatedEntity.addr">
       <path value="AssociatedEntity.addr"/>
-      <definition value="Element AssociatedEntity.addr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -100,7 +95,6 @@
     </element>
     <element id="AssociatedEntity.telecom">
       <path value="AssociatedEntity.telecom"/>
-      <definition value="Element AssociatedEntity.telecom"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -109,7 +103,6 @@
     </element>
     <element id="AssociatedEntity.associatedPerson">
       <path value="AssociatedEntity.associatedPerson"/>
-      <definition value="Element AssociatedEntity.associatedPerson"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -118,7 +111,6 @@
     </element>
     <element id="AssociatedEntity.scopingOrganization">
       <path value="AssociatedEntity.scopingOrganization"/>
-      <definition value="Element AssociatedEntity.scopingOrganization"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Authenticator.xml
+++ b/input/resources/Authenticator.xml
@@ -40,6 +40,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="AUTHEN"/>
       

--- a/input/resources/Authenticator.xml
+++ b/input/resources/Authenticator.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Authenticator">
       <path value="Authenticator"/>
-      <definition value="Element Authenticator"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Authenticator.nullFlavor">
       <path value="Authenticator.nullFlavor"/>
-      <definition value="Element Authenticator.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
       <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
@@ -49,7 +47,6 @@
     </element>
     <element id="Authenticator.typeCode">
       <path value="Authenticator.typeCode"/>
-      <definition value="Element Authenticator.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -66,7 +63,6 @@
     </element>
     <element id="Authenticator.realmCode">
       <path value="Authenticator.realmCode"/>
-      <definition value="Element Authenticator.realmCode"/>
       <definition value="When valued in an instance, this attribute signals the imposition of realm-specific constraints. The value of this attribute identifies the realm in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -76,7 +72,6 @@
     </element>
     <element id="Authenticator.typeId">
       <path value="Authenticator.typeId"/>
-      <definition value="Element Authenticator.typeId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of constraints defined in an HL7-specified message type. This might be a common type (also known as CMET in the messaging communication environment), or content included within a wrapper. The value of this attribute provides a unique identifier for the type in question."/>
       <min value="0"/>
       <max value="1"/>
@@ -86,7 +81,6 @@
     </element>
     <element id="Authenticator.templateId">
       <path value="Authenticator.templateId"/>
-      <definition value="Element Authenticator.templateId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -96,7 +90,6 @@
     </element>
     <element id="Authenticator.time">
       <path value="Authenticator.time"/>
-      <definition value="Element Authenticator.time"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -105,7 +98,6 @@
     </element>
     <element id="Authenticator.signatureCode">
       <path value="Authenticator.signatureCode"/>
-      <definition value="Element Authenticator.signatureCode"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -129,7 +121,6 @@
     </element>
     <element id="Authenticator.assignedEntity">
       <path value="Authenticator.assignedEntity"/>
-      <definition value="Element Authenticator.assignedEntity"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Author.xml
+++ b/input/resources/Author.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Author">
       <path value="Author"/>
-      <definition value="Element Author"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Author.nullFlavor">
       <path value="Author.nullFlavor"/>
-      <definition value="Element Author.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
       <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
@@ -49,7 +47,6 @@
     </element>
     <element id="Author.typeCode">
       <path value="Author.typeCode"/>
-      <definition value="Element Author.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -66,7 +63,6 @@
     </element>
     <element id="Author.contextControlCode">
       <path value="Author.contextControlCode"/>
-      <definition value="Element Author.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -83,7 +79,6 @@
     </element>
     <element id="Author.realmCode">
       <path value="Author.realmCode"/>
-      <definition value="Element Author.realmCode"/>
       <definition value="When valued in an instance, this attribute signals the imposition of realm-specific constraints. The value of this attribute identifies the realm in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -93,7 +88,6 @@
     </element>
     <element id="Author.typeId">
       <path value="Author.typeId"/>
-      <definition value="Element Author.typeId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of constraints defined in an HL7-specified message type. This might be a common type (also known as CMET in the messaging communication environment), or content included within a wrapper. The value of this attribute provides a unique identifier for the type in question."/>
       <min value="0"/>
       <max value="1"/>
@@ -103,7 +97,6 @@
     </element>
     <element id="Author.templateId">
       <path value="Author.templateId"/>
-      <definition value="Element Author.templateId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -113,7 +106,6 @@
     </element>
     <element id="Author.functionCode">
       <path value="Author.functionCode"/>
-      <definition value="Element Author.functionCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -123,7 +115,6 @@
     </element>
     <element id="Author.time">
       <path value="Author.time"/>
-      <definition value="Element Author.time"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -133,7 +124,6 @@
     </element>
     <element id="Author.assignedAuthor">
       <path value="Author.assignedAuthor"/>
-      <definition value="Element Author.assignedAuthor"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Author.xml
+++ b/input/resources/Author.xml
@@ -40,6 +40,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="AUT"/>
       
@@ -70,6 +72,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="OP"/>
       

--- a/input/resources/AuthoringDevice.xml
+++ b/input/resources/AuthoringDevice.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="DEV"/>
       <fixedCode value="DEV"/>
@@ -48,6 +49,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INSTANCE"/>
       <fixedCode value="INSTANCE"/>

--- a/input/resources/AuthoringDevice.xml
+++ b/input/resources/AuthoringDevice.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="AuthoringDevice">
       <path value="AuthoringDevice"/>
-      <definition value="Element AuthoringDevice"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="AuthoringDevice.classCode">
       <path value="AuthoringDevice.classCode"/>
-      <definition value="Element AuthoringDevice.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -43,7 +41,6 @@
     </element>
     <element id="AuthoringDevice.determinerCode">
       <path value="AuthoringDevice.determinerCode"/>
-      <definition value="Element AuthoringDevice.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -61,7 +58,6 @@
     </element>
     <element id="AuthoringDevice.templateId">
       <path value="AuthoringDevice.templateId"/>
-      <definition value="Element AuthoringDevice.templateId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -71,7 +67,6 @@
     </element>
     <element id="AuthoringDevice.code">
       <path value="AuthoringDevice.code"/>
-      <definition value="Element AuthoringDevice.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -84,7 +79,6 @@
     </element>
     <element id="AuthoringDevice.manufacturerModelName">
       <path value="AuthoringDevice.manufacturerModelName"/>
-      <definition value="Element AuthoringDevice.manufacturerModelName"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -97,7 +91,6 @@
     </element>
     <element id="AuthoringDevice.softwareName">
       <path value="AuthoringDevice.softwareName"/>
-      <definition value="Element AuthoringDevice.softwareName"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -110,7 +103,6 @@
     </element>
     <element id="AuthoringDevice.asMaintainedEntity">
       <path value="AuthoringDevice.asMaintainedEntity"/>
-      <definition value="Element AuthoringDevice.asMaintainedEntity"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/Authorization.xml
+++ b/input/resources/Authorization.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="AUTH"/>
       <binding>

--- a/input/resources/Authorization.xml
+++ b/input/resources/Authorization.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="Authorization">
       <path value="Authorization"/>
-      <definition value="Element Authorization"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="Authorization.typeCode">
       <path value="Authorization.typeCode"/>
-      <definition value="Element Authorization.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -90,7 +88,6 @@
     </element>
     <element id="Authorization.consent">
       <path value="Authorization.consent"/>
-      <definition value="Element Authorization.consent"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/BL.xml
+++ b/input/resources/BL.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
   </differential>

--- a/input/resources/Birthplace.xml
+++ b/input/resources/Birthplace.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="BIRTHPL"/>
       <fixedCode value="BIRTHPL"/>

--- a/input/resources/Birthplace.xml
+++ b/input/resources/Birthplace.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="Birthplace">
       <path value="Birthplace"/>
-      <definition value="Element Birthplace"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Birthplace.classCode">
       <path value="Birthplace.classCode"/>
-      <definition value="Element Birthplace.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -58,7 +56,6 @@
     </element>
     <element id="Birthplace.place">
       <path value="Birthplace.place"/>
-      <definition value="Element Birthplace.place"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/CD.xml
+++ b/input/resources/CD.xml
@@ -43,7 +43,8 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="CD.codeSystem">
@@ -69,6 +70,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
     <element id="CD.codeSystemVersion">
@@ -80,6 +82,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
     <element id="CD.displayName">
@@ -91,6 +94,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
     <element id="CD.sdtcValueSet">
@@ -111,7 +115,8 @@
         <max value="1"/>
       </base>
       <type>
-        <code value="string"/>
+        <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="CD.sdtcValueSetVersion">
@@ -128,6 +133,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
     <element id="CD.originalText">

--- a/input/resources/CD.xml
+++ b/input/resources/CD.xml
@@ -55,7 +55,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="id"/>
+        <code value="string"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/oid"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/uuid"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/ruid"/>
@@ -115,8 +115,8 @@
         <max value="1"/>
       </base>
       <type>
-        <code value="code"/>
-        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
+        <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/oid"/>
       </type>
     </element>
     <element id="CD.sdtcValueSetVersion">

--- a/input/resources/CD.xml
+++ b/input/resources/CD.xml
@@ -54,7 +54,10 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="id"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/oid"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/uuid"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/ruid"/>
       </type>
     </element>
     <element id="CD.codeSystemName">

--- a/input/resources/CR.xml
+++ b/input/resources/CR.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bn"/>
       </type>
     </element>
     <element id="CR.name">

--- a/input/resources/CS.xml
+++ b/input/resources/CS.xml
@@ -50,9 +50,6 @@
       <label value="Code System Name"/>
       <min value="0"/>
       <max value="0"/>
-      <type>
-        <code value="string"/>
-      </type>
     </element>
     <element id="CS.codeSystemVersion">
       <path value="CS.codeSystemVersion"/>
@@ -61,9 +58,6 @@
       <label value="Code System Version"/>
       <min value="0"/>
       <max value="0"/>
-      <type>
-        <code value="string"/>
-      </type>
     </element>
     <element id="CS.displayName">
       <path value="CS.displayName"/>
@@ -72,41 +66,6 @@
       <label value="Display Name"/>
       <min value="0"/>
       <max value="0"/>
-      <type>
-        <code value="string"/>
-      </type>
-    </element>
-    <element id="CS.sdtcValueSet">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
-        <valueUri value="urn:hl7-org:sdtc"/>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
-        <valueString value="valueSet"/>
-      </extension>
-      <path value="CS.sdtcValueSet"/>
-      <definition value="Element CS.sdtcValueSet"/>
-      <representation value="xmlAttr"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
-    </element>
-    <element id="CS.sdtcValueSetVersion">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
-        <valueUri value="urn:hl7-org:sdtc"/>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-xml-name">
-        <valueString value="valueSetVersion"/>
-      </extension>
-      <path value="CS.sdtcValueSetVersion"/>
-      <representation value="xmlAttr"/>
-      <definition value="The valueSetVersion extension adds an attribute for elements with a CD dataType which indicates the version of the particular value set constraining the coded concept."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
     </element>
     <element id="CS.originalText">
       <path value="CS.originalText"/>
@@ -114,9 +73,6 @@
       <label value="Original Text"/>
       <min value="0"/>
       <max value="0"/>
-      <type>
-        <code value="http://hl7.org/cda/stds/core/StructureDefinition/ED"/>
-      </type>
     </element>
   </differential>
 </StructureDefinition>

--- a/input/resources/CS.xml
+++ b/input/resources/CS.xml
@@ -22,7 +22,7 @@
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
-  <description value="XCoded data in its simplest form, where only the code is not predetermined. The code system and code system version are fixed by the context in which the CS value occurs. CS is used for coded attributes that have a single HL7-defined value set."/>
+  <description value="Coded data in its simplest form, where only the code is not predetermined. The code system and code system version are fixed by the context in which the CS value occurs. CS is used for coded attributes that have a single HL7-defined value set."/>
   <kind value="logical"/>
   <abstract value="false"/>
   <type value="http://hl7.org/cda/stds/core/StructureDefinition/CS"/>
@@ -31,7 +31,7 @@
   <differential>
     <element id="CS">
       <path value="CS"/>
-      <definition value="Coded data, consists of a code, display name, code system, and original text. Used when a single code value must be sent."/>
+      <definition value="Coded data in its simplest form, where only the code is not predetermined. Used when a single code value must be sent."/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/input/resources/CS.xml
+++ b/input/resources/CS.xml
@@ -37,7 +37,6 @@
     </element>
     <element id="CS.codeSystem">
       <path value="CS.codeSystem"/>
-      <definition value="Element CS.codeSystem"/>
       <representation value="xmlAttr"/>
       <label value="Code System"/>
       <min value="0"/>
@@ -45,7 +44,6 @@
     </element>
     <element id="CS.codeSystemName">
       <path value="CS.codeSystemName"/>
-      <definition value="Element CS.codeSystemName"/>
       <representation value="xmlAttr"/>
       <label value="Code System Name"/>
       <min value="0"/>
@@ -53,7 +51,6 @@
     </element>
     <element id="CS.codeSystemVersion">
       <path value="CS.codeSystemVersion"/>
-      <definition value="Element CS.codeSystemVersion"/>
       <representation value="xmlAttr"/>
       <label value="Code System Version"/>
       <min value="0"/>
@@ -61,7 +58,6 @@
     </element>
     <element id="CS.displayName">
       <path value="CS.displayName"/>
-      <definition value="Element CS.displayName"/>
       <representation value="xmlAttr"/>
       <label value="Display Name"/>
       <min value="0"/>
@@ -69,7 +65,6 @@
     </element>
     <element id="CS.originalText">
       <path value="CS.originalText"/>
-      <definition value="Element CS.originalText"/>
       <label value="Original Text"/>
       <min value="0"/>
       <max value="0"/>

--- a/input/resources/CS.xml
+++ b/input/resources/CS.xml
@@ -42,9 +42,6 @@
       <label value="Code System"/>
       <min value="0"/>
       <max value="0"/>
-      <type>
-        <code value="string"/>
-      </type>
     </element>
     <element id="CS.codeSystemName">
       <path value="CS.codeSystemName"/>

--- a/input/resources/ClinicalDocument.xml
+++ b/input/resources/ClinicalDocument.xml
@@ -40,6 +40,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="DOCCLIN"/>
       <fixedCode value="DOCCLIN"/>
@@ -57,6 +58,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>

--- a/input/resources/ClinicalDocument.xml
+++ b/input/resources/ClinicalDocument.xml
@@ -28,13 +28,11 @@
   <differential>
     <element id="ClinicalDocument">
       <path value="ClinicalDocument"/>
-      <definition value="Element ClinicalDocument"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ClinicalDocument.classCode">
       <path value="ClinicalDocument.classCode"/>
-      <definition value="Element ClinicalDocument.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -52,7 +50,6 @@
     </element>
     <element id="ClinicalDocument.moodCode">
       <path value="ClinicalDocument.moodCode"/>
-      <definition value="Element ClinicalDocument.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -97,7 +94,6 @@
     </element>
     <element id="ClinicalDocument.id">
       <path value="ClinicalDocument.id"/>
-      <definition value="Element ClinicalDocument.id"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -106,7 +102,6 @@
     </element>
     <element id="ClinicalDocument.code">
       <path value="ClinicalDocument.code"/>
-      <definition value="Element ClinicalDocument.code"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -119,7 +114,6 @@
     </element>
     <element id="ClinicalDocument.title">
       <path value="ClinicalDocument.title"/>
-      <definition value="Element ClinicalDocument.title"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -128,7 +122,6 @@
     </element>
     <element id="ClinicalDocument.effectiveTime">
       <path value="ClinicalDocument.effectiveTime"/>
-      <definition value="Element ClinicalDocument.effectiveTime"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -137,7 +130,6 @@
     </element>
     <element id="ClinicalDocument.confidentialityCode">
       <path value="ClinicalDocument.confidentialityCode"/>
-      <definition value="Element ClinicalDocument.confidentialityCode"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -146,7 +138,6 @@
     </element>
     <element id="ClinicalDocument.languageCode">
       <path value="ClinicalDocument.languageCode"/>
-      <definition value="Element ClinicalDocument.languageCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -159,7 +150,6 @@
     </element>
     <element id="ClinicalDocument.setId">
       <path value="ClinicalDocument.setId"/>
-      <definition value="Element ClinicalDocument.setId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -168,7 +158,6 @@
     </element>
     <element id="ClinicalDocument.versionNumber">
       <path value="ClinicalDocument.versionNumber"/>
-      <definition value="Element ClinicalDocument.versionNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -177,7 +166,6 @@
     </element>
     <element id="ClinicalDocument.copyTime">
       <path value="ClinicalDocument.copyTime"/>
-      <definition value="Element ClinicalDocument.copyTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -186,7 +174,6 @@
     </element>
     <element id="ClinicalDocument.recordTarget">
       <path value="ClinicalDocument.recordTarget"/>
-      <definition value="Element ClinicalDocument.recordTarget"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -195,7 +182,6 @@
     </element>
     <element id="ClinicalDocument.author">
       <path value="ClinicalDocument.author"/>
-      <definition value="Element ClinicalDocument.author"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -204,7 +190,6 @@
     </element>
     <element id="ClinicalDocument.dataEnterer">
       <path value="ClinicalDocument.dataEnterer"/>
-      <definition value="Element ClinicalDocument.dataEnterer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -213,7 +198,6 @@
     </element>
     <element id="ClinicalDocument.informant">
       <path value="ClinicalDocument.informant"/>
-      <definition value="Element ClinicalDocument.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -222,7 +206,6 @@
     </element>
     <element id="ClinicalDocument.custodian">
       <path value="ClinicalDocument.custodian"/>
-      <definition value="Element ClinicalDocument.custodian"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -231,7 +214,6 @@
     </element>
     <element id="ClinicalDocument.informationRecipient">
       <path value="ClinicalDocument.informationRecipient"/>
-      <definition value="Element ClinicalDocument.informationRecipient"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -240,7 +222,6 @@
     </element>
     <element id="ClinicalDocument.legalAuthenticator">
       <path value="ClinicalDocument.legalAuthenticator"/>
-      <definition value="Element ClinicalDocument.legalAuthenticator"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -249,7 +230,6 @@
     </element>
     <element id="ClinicalDocument.authenticator">
       <path value="ClinicalDocument.authenticator"/>
-      <definition value="Element ClinicalDocument.authenticator"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -258,7 +238,6 @@
     </element>
     <element id="ClinicalDocument.participant">
       <path value="ClinicalDocument.participant"/>
-      <definition value="Element ClinicalDocument.participant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -267,7 +246,6 @@
     </element>
     <element id="ClinicalDocument.inFulfillmentOf">
       <path value="ClinicalDocument.inFulfillmentOf"/>
-      <definition value="Element ClinicalDocument.inFulfillmentOf"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -276,7 +254,6 @@
     </element>
     <element id="ClinicalDocument.documentationOf">
       <path value="ClinicalDocument.documentationOf"/>
-      <definition value="Element ClinicalDocument.documentationOf"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -285,7 +262,6 @@
     </element>
     <element id="ClinicalDocument.relatedDocument">
       <path value="ClinicalDocument.relatedDocument"/>
-      <definition value="Element ClinicalDocument.relatedDocument"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -294,7 +270,6 @@
     </element>
     <element id="ClinicalDocument.authorization">
       <path value="ClinicalDocument.authorization"/>
-      <definition value="Element ClinicalDocument.authorization"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -303,7 +278,6 @@
     </element>
     <element id="ClinicalDocument.componentOf">
       <path value="ClinicalDocument.componentOf"/>
-      <definition value="Element ClinicalDocument.componentOf"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -312,7 +286,6 @@
     </element>
     <element id="ClinicalDocument.component">
       <path value="ClinicalDocument.component"/>
-      <definition value="Element ClinicalDocument.component"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Component2.xml
+++ b/input/resources/Component2.xml
@@ -75,6 +75,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
     </element>

--- a/input/resources/Component2.xml
+++ b/input/resources/Component2.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="Component2">
       <path value="Component2"/>
-      <definition value="Element Component2"/>
       <min value="1"/>
       <max value="1"/>
       <constraint>
@@ -53,7 +52,6 @@
     </element>
     <element id="Component2.typeCode">
       <path value="Component2.typeCode"/>
-      <definition value="Element Component2.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -69,7 +67,6 @@
     </element>
     <element id="Component2.contextConductionInd">
       <path value="Component2.contextConductionInd"/>
-      <definition value="Element Component2.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -108,7 +105,6 @@
     </element>
     <element id="Component2.nonXMLBody">
       <path value="Component2.nonXMLBody"/>
-      <definition value="Element Component2.nonXMLBody"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -117,7 +113,6 @@
     </element>
     <element id="Component2.structuredBody">
       <path value="Component2.structuredBody"/>
-      <definition value="Element Component2.structuredBody"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Component2.xml
+++ b/input/resources/Component2.xml
@@ -44,6 +44,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -58,6 +59,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="AUT"/>
       <binding>

--- a/input/resources/ComponentOf.xml
+++ b/input/resources/ComponentOf.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="ComponentOf">
       <path value="ComponentOf"/>
-      <definition value="Element ComponentOf"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="ComponentOf.typeCode">
       <path value="ComponentOf.typeCode"/>
-      <definition value="Element ComponentOf.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -90,7 +88,6 @@
     </element>
     <element id="ComponentOf.encompassingEncounter">
       <path value="ComponentOf.encompassingEncounter"/>
-      <definition value="Element ComponentOf.encompassingEncounter"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/ComponentOf.xml
+++ b/input/resources/ComponentOf.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="AUT"/>
       <binding>

--- a/input/resources/Consent.xml
+++ b/input/resources/Consent.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="CONS"/>
       <fixedCode value="CONS"/>
@@ -53,6 +54,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>

--- a/input/resources/Consent.xml
+++ b/input/resources/Consent.xml
@@ -111,14 +111,15 @@
     <element id="Consent.statusCode.code">
       <path value="Consent.statusCode.code"/>
       <definition value="Element Consent.statusCode.code"/>
+      <comment value="Consents referenced in the CDA Header have been finalized (Consent.statusCode must equal &quot;completed&quot;) and should be on file."/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
-      <defaultValueString value="completed"/>
-      <fixedString value="completed"/>
+      <fixedCode value="completed"/>
     </element>
   </differential>
 </StructureDefinition>

--- a/input/resources/Consent.xml
+++ b/input/resources/Consent.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="Consent">
       <path value="Consent"/>
-      <definition value="Element Consent"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Consent.classCode">
       <path value="Consent.classCode"/>
-      <definition value="Element Consent.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -48,7 +46,6 @@
     </element>
     <element id="Consent.moodCode">
       <path value="Consent.moodCode"/>
-      <definition value="Element Consent.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -75,7 +72,6 @@
     </element>
     <element id="Consent.id">
       <path value="Consent.id"/>
-      <definition value="Element Consent.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -84,7 +80,6 @@
     </element>
     <element id="Consent.code">
       <path value="Consent.code"/>
-      <definition value="Element Consent.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -97,7 +92,6 @@
     </element>
     <element id="Consent.statusCode">
       <path value="Consent.statusCode"/>
-      <definition value="Element Consent.statusCode"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -110,7 +104,6 @@
     </element>
     <element id="Consent.statusCode.code">
       <path value="Consent.statusCode.code"/>
-      <definition value="Element Consent.statusCode.code"/>
       <comment value="Consents referenced in the CDA Header have been finalized (Consent.statusCode must equal &quot;completed&quot;) and should be on file."/>
       <representation value="xmlAttr"/>
       <min value="1"/>

--- a/input/resources/Criterion.xml
+++ b/input/resources/Criterion.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OBS"/>
       
@@ -47,6 +48,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN.CRT"/>
       <fixedCode value="EVN.CRT"/>

--- a/input/resources/Criterion.xml
+++ b/input/resources/Criterion.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="Criterion">
       <path value="Criterion"/>
-      <definition value="Element Criterion"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Criterion.classCode">
       <path value="Criterion.classCode"/>
-      <definition value="Element Criterion.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -42,7 +40,6 @@
     </element>
     <element id="Criterion.moodCode">
       <path value="Criterion.moodCode"/>
-      <definition value="Element Criterion.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -69,7 +66,6 @@
     </element>
     <element id="Criterion.code">
       <path value="Criterion.code"/>
-      <definition value="Element Criterion.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -82,7 +78,6 @@
     </element>
     <element id="Criterion.text">
       <path value="Criterion.text"/>
-      <definition value="Element Criterion.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -91,7 +86,6 @@
     </element>
     <element id="Criterion.value">
       <path value="Criterion.value"/>
-      <definition value="Element Criterion.value"/>
       <representation value="typeAttr"/>
       <min value="0"/>
       <max value="1"/>

--- a/input/resources/Custodian.xml
+++ b/input/resources/Custodian.xml
@@ -26,7 +26,6 @@
   <differential>
     <element id="Custodian">
       <path value="Custodian"/>
-      <definition value="Element Custodian"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -48,7 +47,6 @@
     </element>
     <element id="Custodian.typeCode">
       <path value="Custodian.typeCode"/>
-      <definition value="Element Custodian.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -92,7 +90,6 @@
     </element>
     <element id="Custodian.assignedCustodian">
       <path value="Custodian.assignedCustodian"/>
-      <definition value="Element Custodian.assignedCustodian"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Custodian.xml
+++ b/input/resources/Custodian.xml
@@ -39,6 +39,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -53,6 +54,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="ENT"/>
       

--- a/input/resources/CustodianOrganization.xml
+++ b/input/resources/CustodianOrganization.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="CustodianOrganization">
       <path value="CustodianOrganization"/>
-      <definition value="Element CustodianOrganization"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="CustodianOrganization.classCode">
       <path value="CustodianOrganization.classCode"/>
-      <definition value="Element CustodianOrganization.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -49,7 +47,6 @@
     </element>
     <element id="CustodianOrganization.determinerCode">
       <path value="CustodianOrganization.determinerCode"/>
-      <definition value="Element CustodianOrganization.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -76,7 +73,6 @@
     </element>
     <element id="CustodianOrganization.id">
       <path value="CustodianOrganization.id"/>
-      <definition value="Element CustodianOrganization.id"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -85,7 +81,6 @@
     </element>
     <element id="CustodianOrganization.name">
       <path value="CustodianOrganization.name"/>
-      <definition value="Element CustodianOrganization.name"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -94,7 +89,6 @@
     </element>
     <element id="CustodianOrganization.telecom">
       <path value="CustodianOrganization.telecom"/>
-      <definition value="Element CustodianOrganization.telecom"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -103,7 +97,6 @@
     </element>
     <element id="CustodianOrganization.addr">
       <path value="CustodianOrganization.addr"/>
-      <definition value="Element CustodianOrganization.addr"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/CustodianOrganization.xml
+++ b/input/resources/CustodianOrganization.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ORG"/>
       <fixedCode value="ORG"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INSTANCE"/>
       <fixedCode value="INSTANCE"/>

--- a/input/resources/DataEnterer.xml
+++ b/input/resources/DataEnterer.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="DataEnterer">
       <path value="DataEnterer"/>
-      <definition value="Element DataEnterer"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="DataEnterer.typeCode">
       <path value="DataEnterer.typeCode"/>
-      <definition value="Element DataEnterer.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -64,7 +62,6 @@
     </element>
     <element id="DataEnterer.contextControlCode">
       <path value="DataEnterer.contextControlCode"/>
-      <definition value="Element DataEnterer.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -108,7 +105,6 @@
     </element>
     <element id="DataEnterer.time">
       <path value="DataEnterer.time"/>
-      <definition value="Element DataEnterer.time"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -118,7 +114,6 @@
     </element>
     <element id="DataEnterer.assignedEntity">
       <path value="DataEnterer.assignedEntity"/>
-      <definition value="Element DataEnterer.assignedEntity"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/DataEnterer.xml
+++ b/input/resources/DataEnterer.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="ENT"/>
       
@@ -68,6 +70,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="OP"/>
       

--- a/input/resources/Device.xml
+++ b/input/resources/Device.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Device">
       <path value="Device"/>
-      <definition value="Element Device"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Device.classCode">
       <path value="Device.classCode"/>
-      <definition value="Element Device.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -49,7 +47,6 @@
     </element>
     <element id="Device.determinerCode">
       <path value="Device.determinerCode"/>
-      <definition value="Element Device.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -76,7 +73,6 @@
     </element>
     <element id="Device.code">
       <path value="Device.code"/>
-      <definition value="Element Device.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -89,7 +85,6 @@
     </element>
     <element id="Device.manufacturerModelName">
       <path value="Device.manufacturerModelName"/>
-      <definition value="Element Device.manufacturerModelName"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -102,7 +97,6 @@
     </element>
     <element id="Device.softwareName">
       <path value="Device.softwareName"/>
-      <definition value="Element Device.softwareName"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Device.xml
+++ b/input/resources/Device.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="DEV"/>
       
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INSTANCE"/>
       <fixedCode value="INSTANCE"/>

--- a/input/resources/DocumentationOf.xml
+++ b/input/resources/DocumentationOf.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="DocumentationOf">
       <path value="DocumentationOf"/>
-      <definition value="Element DocumentationOf"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="DocumentationOf.typeCode">
       <path value="DocumentationOf.typeCode"/>
-      <definition value="Element DocumentationOf.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -91,7 +89,6 @@
     </element>
     <element id="DocumentationOf.serviceEvent">
       <path value="DocumentationOf.serviceEvent"/>
-      <definition value="Element DocumentationOf.serviceEvent"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/DocumentationOf.xml
+++ b/input/resources/DocumentationOf.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="DOC"/>
       

--- a/input/resources/ED.xml
+++ b/input/resources/ED.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="ED.compression">
@@ -49,6 +50,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -75,6 +77,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -90,6 +93,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="ED.mediaType">
@@ -101,6 +105,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="ED.representation">
@@ -111,6 +116,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="ED.data[x]">

--- a/input/resources/ED.xml
+++ b/input/resources/ED.xml
@@ -66,6 +66,7 @@
       <max value="1"/>
       <type>
         <code value="base64Binary"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bin"/>
       </type>
     </element>
     <element id="ED.integrityCheckAlgorithm">
@@ -130,6 +131,7 @@
       </type>
       <type>
         <code value="base64Binary"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bin"/>
       </type>
     </element>
     <element id="ED.reference">

--- a/input/resources/ED.xml
+++ b/input/resources/ED.xml
@@ -111,7 +111,6 @@
     </element>
     <element id="ED.representation">
       <path value="ED.representation"/>
-      <definition value="Element ED.representation"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>

--- a/input/resources/ED.xml
+++ b/input/resources/ED.xml
@@ -128,6 +128,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
       <type>
         <code value="base64Binary"/>

--- a/input/resources/EN.xml
+++ b/input/resources/EN.xml
@@ -101,6 +101,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
     <element id="EN.validTime">

--- a/input/resources/EN.xml
+++ b/input/resources/EN.xml
@@ -50,7 +50,6 @@
     </element>
     <element id="EN.delimiter">
       <path value="EN.delimiter"/>
-      <definition value="Element EN.delimiter"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -59,7 +58,6 @@
     </element>
     <element id="EN.family">
       <path value="EN.family"/>
-      <definition value="Element EN.family"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -68,7 +66,6 @@
     </element>
     <element id="EN.given">
       <path value="EN.given"/>
-      <definition value="Element EN.given"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -77,7 +74,6 @@
     </element>
     <element id="EN.prefix">
       <path value="EN.prefix"/>
-      <definition value="Element EN.prefix"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -95,7 +91,6 @@
     </element>
     <element id="EN.other">
       <path value="EN.other"/>
-      <definition value="Element EN.other"/>
       <representation value="xmlText"/>
       <min value="0"/>
       <max value="1"/>

--- a/input/resources/EN.xml
+++ b/input/resources/EN.xml
@@ -41,6 +41,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>

--- a/input/resources/ENXP.xml
+++ b/input/resources/ENXP.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -53,6 +54,7 @@
       <max value="*"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>

--- a/input/resources/ENXP.xml
+++ b/input/resources/ENXP.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="ENXP">
       <path value="ENXP"/>
-      <definition value="Element ENXP"/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/input/resources/EncompassingEncounter.xml
+++ b/input/resources/EncompassingEncounter.xml
@@ -39,6 +39,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ENC"/>
       <fixedCode value="ENC"/>
@@ -56,6 +57,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>
@@ -151,6 +153,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="RESP"/>
       <fixedCode value="RESP"/>
@@ -195,6 +198,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="LOC"/>
       <fixedCode value="LOC"/>

--- a/input/resources/EncompassingEncounter.xml
+++ b/input/resources/EncompassingEncounter.xml
@@ -27,13 +27,11 @@
   <differential>
     <element id="EncompassingEncounter">
       <path value="EncompassingEncounter"/>
-      <definition value="Element EncompassingEncounter"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="EncompassingEncounter.classCode">
       <path value="EncompassingEncounter.classCode"/>
-      <definition value="Element EncompassingEncounter.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -51,7 +49,6 @@
     </element>
     <element id="EncompassingEncounter.moodCode">
       <path value="EncompassingEncounter.moodCode"/>
-      <definition value="Element EncompassingEncounter.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -78,7 +75,6 @@
     </element>
     <element id="EncompassingEncounter.id">
       <path value="EncompassingEncounter.id"/>
-      <definition value="Element EncompassingEncounter.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -87,7 +83,6 @@
     </element>
     <element id="EncompassingEncounter.code">
       <path value="EncompassingEncounter.code"/>
-      <definition value="Element EncompassingEncounter.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -100,7 +95,6 @@
     </element>
     <element id="EncompassingEncounter.effectiveTime">
       <path value="EncompassingEncounter.effectiveTime"/>
-      <definition value="Element EncompassingEncounter.effectiveTime"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -116,7 +110,6 @@
         <valueString value="admissionReferralSourceCode"/>
       </extension>
       <path value="EncompassingEncounter.sdtcAdmissionReferralSourceCode"/>
-      <definition value="Element EncompassingEncounter.sdtcAdmissionReferralSourceCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -125,7 +118,6 @@
     </element>
     <element id="EncompassingEncounter.dischargeDispositionCode">
       <path value="EncompassingEncounter.dischargeDispositionCode"/>
-      <definition value="Element EncompassingEncounter.dischargeDispositionCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -138,7 +130,6 @@
     </element>
     <element id="EncompassingEncounter.responsibleParty">
       <path value="EncompassingEncounter.responsibleParty"/>
-      <definition value="Element EncompassingEncounter.responsibleParty"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -147,7 +138,6 @@
     </element>
     <element id="EncompassingEncounter.responsibleParty.typeCode">
       <path value="EncompassingEncounter.responsibleParty.typeCode"/>
-      <definition value="Element EncompassingEncounter.responsibleParty.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -165,7 +155,6 @@
     </element>
     <element id="EncompassingEncounter.responsibleParty.assignedEntity">
       <path value="EncompassingEncounter.responsibleParty.assignedEntity"/>
-      <definition value="Element EncompassingEncounter.responsibleParty.assignedEntity"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -174,7 +163,6 @@
     </element>
     <element id="EncompassingEncounter.encounterParticipant">
       <path value="EncompassingEncounter.encounterParticipant"/>
-      <definition value="Element EncompassingEncounter.encounterParticipant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -183,7 +171,6 @@
     </element>
     <element id="EncompassingEncounter.location">
       <path value="EncompassingEncounter.location"/>
-      <definition value="Element EncompassingEncounter.location"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -192,7 +179,6 @@
     </element>
     <element id="EncompassingEncounter.location.typeCode">
       <path value="EncompassingEncounter.location.typeCode"/>
-      <definition value="Element EncompassingEncounter.location.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -210,7 +196,6 @@
     </element>
     <element id="EncompassingEncounter.location.healthCareFacility">
       <path value="EncompassingEncounter.location.healthCareFacility"/>
-      <definition value="Element EncompassingEncounter.location.healthCareFacility"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Encounter.xml
+++ b/input/resources/Encounter.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="ENC"/>
       <binding>
@@ -53,6 +54,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="Encounter.realmCode">
@@ -180,6 +182,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBJ"/>
       <fixedCode value="SBJ"/>
@@ -197,6 +200,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -272,6 +276,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INF"/>
       <fixedCode value="INF"/>
@@ -288,6 +293,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -347,6 +353,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="Encounter.entryRelationship.inversionInd">
@@ -497,6 +504,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>

--- a/input/resources/Encounter.xml
+++ b/input/resources/Encounter.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Encounter">
       <path value="Encounter"/>
-      <definition value="Element Encounter"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Encounter.classCode">
       <path value="Encounter.classCode"/>
-      <definition value="Element Encounter.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -48,7 +46,6 @@
     </element>
     <element id="Encounter.moodCode">
       <path value="Encounter.moodCode"/>
-      <definition value="Element Encounter.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -59,7 +56,6 @@
     </element>
     <element id="Encounter.realmCode">
       <path value="Encounter.realmCode"/>
-      <definition value="Element Encounter.realmCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -68,7 +64,6 @@
     </element>
     <element id="Encounter.typeId">
       <path value="Encounter.typeId"/>
-      <definition value="Element Encounter.typeId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -86,7 +81,6 @@
     </element>
     <element id="Encounter.id">
       <path value="Encounter.id"/>
-      <definition value="Element Encounter.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -95,7 +89,6 @@
     </element>
     <element id="Encounter.code">
       <path value="Encounter.code"/>
-      <definition value="Element Encounter.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -108,7 +101,6 @@
     </element>
     <element id="Encounter.text">
       <path value="Encounter.text"/>
-      <definition value="Element Encounter.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -117,7 +109,6 @@
     </element>
     <element id="Encounter.statusCode">
       <path value="Encounter.statusCode"/>
-      <definition value="Element Encounter.statusCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -130,7 +121,6 @@
     </element>
     <element id="Encounter.effectiveTime">
       <path value="Encounter.effectiveTime"/>
-      <definition value="Element Encounter.effectiveTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -145,7 +135,6 @@
         <valueUri value="dischargeDispositionCode"/>
       </extension>
       <path value="Encounter.sdtcDischargeDispositionCode"/>
-      <definition value="Element Encounter.sdtcDischargeDispositionCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -154,7 +143,6 @@
     </element>
     <element id="Encounter.priorityCode">
       <path value="Encounter.priorityCode"/>
-      <definition value="Element Encounter.priorityCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -167,7 +155,6 @@
     </element>
     <element id="Encounter.subject">
       <path value="Encounter.subject"/>
-      <definition value="Element Encounter.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -176,7 +163,6 @@
     </element>
     <element id="Encounter.subject.typeCode">
       <path value="Encounter.subject.typeCode"/>
-      <definition value="Element Encounter.subject.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -194,7 +180,6 @@
     </element>
     <element id="Encounter.subject.contextControlCode">
       <path value="Encounter.subject.contextControlCode"/>
-      <definition value="Element Encounter.subject.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -212,7 +197,6 @@
     </element>
     <element id="Encounter.subject.awarenessCode">
       <path value="Encounter.subject.awarenessCode"/>
-      <definition value="Element Encounter.subject.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -225,7 +209,6 @@
     </element>
     <element id="Encounter.subject.relatedSubject">
       <path value="Encounter.subject.relatedSubject"/>
-      <definition value="Element Encounter.subject.relatedSubject"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -234,7 +217,6 @@
     </element>
     <element id="Encounter.specimen">
       <path value="Encounter.specimen"/>
-      <definition value="Element Encounter.specimen"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -243,7 +225,6 @@
     </element>
     <element id="Encounter.performer">
       <path value="Encounter.performer"/>
-      <definition value="Element Encounter.performer"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -252,7 +233,6 @@
     </element>
     <element id="Encounter.author">
       <path value="Encounter.author"/>
-      <definition value="Element Encounter.author"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -261,7 +241,6 @@
     </element>
     <element id="Encounter.informant">
       <path value="Encounter.informant"/>
-      <definition value="Element Encounter.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -270,7 +249,6 @@
     </element>
     <element id="Encounter.informant.typeCode">
       <path value="Encounter.informant.typeCode"/>
-      <definition value="Element Encounter.informant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -287,7 +265,6 @@
     </element>
     <element id="Encounter.informant.contextControlCode">
       <path value="Encounter.informant.contextControlCode"/>
-      <definition value="Element Encounter.informant.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -304,7 +281,6 @@
     </element>
     <element id="Encounter.informant.assignedEntity">
       <path value="Encounter.informant.assignedEntity"/>
-      <definition value="Element Encounter.informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -313,7 +289,6 @@
     </element>
     <element id="Encounter.informant.relatedEntity">
       <path value="Encounter.informant.relatedEntity"/>
-      <definition value="Element Encounter.informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -322,7 +297,6 @@
     </element>
     <element id="Encounter.participant">
       <path value="Encounter.participant"/>
-      <definition value="Element Encounter.participant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -331,7 +305,6 @@
     </element>
     <element id="Encounter.entryRelationship">
       <path value="Encounter.entryRelationship"/>
-      <definition value="Element Encounter.entryRelationship"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -347,7 +320,6 @@
     </element>
     <element id="Encounter.entryRelationship.typeCode">
       <path value="Encounter.entryRelationship.typeCode"/>
-      <definition value="Element Encounter.entryRelationship.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -358,7 +330,6 @@
     </element>
     <element id="Encounter.entryRelationship.inversionInd">
       <path value="Encounter.entryRelationship.inversionInd"/>
-      <definition value="Element Encounter.entryRelationship.inversionInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -369,7 +340,6 @@
     </element>
     <element id="Encounter.entryRelationship.contextConductionInd">
       <path value="Encounter.entryRelationship.contextConductionInd"/>
-      <definition value="Element Encounter.entryRelationship.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -382,7 +352,6 @@
     </element>
     <element id="Encounter.entryRelationship.sequenceNumber">
       <path value="Encounter.entryRelationship.sequenceNumber"/>
-      <definition value="Element Encounter.entryRelationship.sequenceNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -391,7 +360,6 @@
     </element>
     <element id="Encounter.entryRelationship.negationInd">
       <path value="Encounter.entryRelationship.negationInd"/>
-      <definition value="Element Encounter.entryRelationship.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -402,7 +370,6 @@
     </element>
     <element id="Encounter.entryRelationship.seperatableInd">
       <path value="Encounter.entryRelationship.seperatableInd"/>
-      <definition value="Element Encounter.entryRelationship.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -411,7 +378,6 @@
     </element>
     <element id="Encounter.entryRelationship.observation">
       <path value="Encounter.entryRelationship.observation"/>
-      <definition value="Element Encounter.entryRelationship.observation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -420,7 +386,6 @@
     </element>
     <element id="Encounter.entryRelationship.regionOfInterest">
       <path value="Encounter.entryRelationship.regionOfInterest"/>
-      <definition value="Element Encounter.entryRelationship.regionOfInterest"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -429,7 +394,6 @@
     </element>
     <element id="Encounter.entryRelationship.observationMedia">
       <path value="Encounter.entryRelationship.observationMedia"/>
-      <definition value="Element Encounter.entryRelationship.observationMedia"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -438,7 +402,6 @@
     </element>
     <element id="Encounter.entryRelationship.substanceAdministration">
       <path value="Encounter.entryRelationship.substanceAdministration"/>
-      <definition value="Element Encounter.entryRelationship.substanceAdministration"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -447,7 +410,6 @@
     </element>
     <element id="Encounter.entryRelationship.supply">
       <path value="Encounter.entryRelationship.supply"/>
-      <definition value="Element Encounter.entryRelationship.supply"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -456,7 +418,6 @@
     </element>
     <element id="Encounter.entryRelationship.procedure">
       <path value="Encounter.entryRelationship.procedure"/>
-      <definition value="Element Encounter.entryRelationship.procedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -465,7 +426,6 @@
     </element>
     <element id="Encounter.entryRelationship.encounter">
       <path value="Encounter.entryRelationship.encounter"/>
-      <definition value="Element Encounter.entryRelationship.encounter"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -474,7 +434,6 @@
     </element>
     <element id="Encounter.entryRelationship.organizer">
       <path value="Encounter.entryRelationship.organizer"/>
-      <definition value="Element Encounter.entryRelationship.organizer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -483,7 +442,6 @@
     </element>
     <element id="Encounter.entryRelationship.act">
       <path value="Encounter.entryRelationship.act"/>
-      <definition value="Element Encounter.entryRelationship.act"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -492,7 +450,6 @@
     </element>
     <element id="Encounter.reference">
       <path value="Encounter.reference"/>
-      <definition value="Element Encounter.reference"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -501,7 +458,6 @@
     </element>
     <element id="Encounter.reference.typeCode">
       <path value="Encounter.reference.typeCode"/>
-      <definition value="Element Encounter.reference.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -513,7 +469,6 @@
     </element>
     <element id="Encounter.reference.seperatableInd">
       <path value="Encounter.reference.seperatableInd"/>
-      <definition value="Element Encounter.reference.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -522,7 +477,6 @@
     </element>
     <element id="Encounter.reference.externalAct">
       <path value="Encounter.reference.externalAct"/>
-      <definition value="Element Encounter.reference.externalAct"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -531,7 +485,6 @@
     </element>
     <element id="Encounter.reference.externalObservation">
       <path value="Encounter.reference.externalObservation"/>
-      <definition value="Element Encounter.reference.externalObservation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -540,7 +493,6 @@
     </element>
     <element id="Encounter.reference.externalProcedure">
       <path value="Encounter.reference.externalProcedure"/>
-      <definition value="Element Encounter.reference.externalProcedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -549,7 +501,6 @@
     </element>
     <element id="Encounter.reference.externalDocument">
       <path value="Encounter.reference.externalDocument"/>
-      <definition value="Element Encounter.reference.externalDocument"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -558,7 +509,6 @@
     </element>
     <element id="Encounter.precondition">
       <path value="Encounter.precondition"/>
-      <definition value="Element Encounter.precondition"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/Encounter.xml
+++ b/input/resources/Encounter.xml
@@ -364,6 +364,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Encounter.entryRelationship.contextConductionInd">
@@ -374,6 +375,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
       
@@ -395,6 +397,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Encounter.entryRelationship.seperatableInd">

--- a/input/resources/EncounterParticipant.xml
+++ b/input/resources/EncounterParticipant.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>

--- a/input/resources/EncounterParticipant.xml
+++ b/input/resources/EncounterParticipant.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="EncounterParticipant">
       <path value="EncounterParticipant"/>
-      <definition value="Element EncounterParticipant"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="EncounterParticipant.typeCode">
       <path value="EncounterParticipant.typeCode"/>
-      <definition value="Element EncounterParticipant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -89,7 +87,6 @@
     </element>
     <element id="EncounterParticipant.time">
       <path value="EncounterParticipant.time"/>
-      <definition value="Element EncounterParticipant.time"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -98,7 +95,6 @@
     </element>
     <element id="EncounterParticipant.assignedEntity">
       <path value="EncounterParticipant.assignedEntity"/>
-      <definition value="Element EncounterParticipant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Entity.xml
+++ b/input/resources/Entity.xml
@@ -39,6 +39,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ENT"/>
       
@@ -55,6 +56,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INSTANCE"/>
       <fixedCode value="INSTANCE"/>

--- a/input/resources/Entity.xml
+++ b/input/resources/Entity.xml
@@ -27,13 +27,11 @@
   <differential>
     <element id="Entity">
       <path value="Entity"/>
-      <definition value="Element Entity"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Entity.classCode">
       <path value="Entity.classCode"/>
-      <definition value="Element Entity.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -50,7 +48,6 @@
     </element>
     <element id="Entity.determinerCode">
       <path value="Entity.determinerCode"/>
-      <definition value="Element Entity.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -77,7 +74,6 @@
     </element>
     <element id="Entity.id">
       <path value="Entity.id"/>
-      <definition value="Element Entity.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -86,7 +82,6 @@
     </element>
     <element id="Entity.code">
       <path value="Entity.code"/>
-      <definition value="Element Entity.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -99,7 +94,6 @@
     </element>
     <element id="Entity.desc">
       <path value="Entity.desc"/>
-      <definition value="Element Entity.desc"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/ExternalAct.xml
+++ b/input/resources/ExternalAct.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ACT"/>
       
@@ -53,6 +54,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>

--- a/input/resources/ExternalAct.xml
+++ b/input/resources/ExternalAct.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="ExternalAct">
       <path value="ExternalAct"/>
-      <definition value="Element ExternalAct"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ExternalAct.classCode">
       <path value="ExternalAct.classCode"/>
-      <definition value="Element ExternalAct.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -48,7 +46,6 @@
     </element>
     <element id="ExternalAct.moodCode">
       <path value="ExternalAct.moodCode"/>
-      <definition value="Element ExternalAct.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -75,7 +72,6 @@
     </element>
     <element id="ExternalAct.id">
       <path value="ExternalAct.id"/>
-      <definition value="Element ExternalAct.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -84,7 +80,6 @@
     </element>
     <element id="ExternalAct.code">
       <path value="ExternalAct.code"/>
-      <definition value="Element ExternalAct.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -97,7 +92,6 @@
     </element>
     <element id="ExternalAct.text">
       <path value="ExternalAct.text"/>
-      <definition value="Element ExternalAct.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/ExternalDocument.xml
+++ b/input/resources/ExternalDocument.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="ExternalDocument">
       <path value="ExternalDocument"/>
-      <definition value="Element ExternalDocument"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ExternalDocument.classCode">
       <path value="ExternalDocument.classCode"/>
-      <definition value="Element ExternalDocument.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -47,7 +45,6 @@
     </element>
     <element id="ExternalDocument.moodCode">
       <path value="ExternalDocument.moodCode"/>
-      <definition value="Element ExternalDocument.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -73,7 +70,6 @@
     </element>
     <element id="ExternalDocument.id">
       <path value="ExternalDocument.id"/>
-      <definition value="Element ExternalDocument.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -82,7 +78,6 @@
     </element>
     <element id="ExternalDocument.code">
       <path value="ExternalDocument.code"/>
-      <definition value="Element ExternalDocument.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -95,7 +90,6 @@
     </element>
     <element id="ExternalDocument.text">
       <path value="ExternalDocument.text"/>
-      <definition value="Element ExternalDocument.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -104,7 +98,6 @@
     </element>
     <element id="ExternalDocument.setId">
       <path value="ExternalDocument.setId"/>
-      <definition value="Element ExternalDocument.setId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -113,7 +106,6 @@
     </element>
     <element id="ExternalDocument.versionNumber">
       <path value="ExternalDocument.versionNumber"/>
-      <definition value="Element ExternalDocument.versionNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/ExternalDocument.xml
+++ b/input/resources/ExternalDocument.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="DOC"/>
       <binding>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>

--- a/input/resources/ExternalObservation.xml
+++ b/input/resources/ExternalObservation.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="ExternalObservation">
       <path value="ExternalObservation"/>
-      <definition value="Element ExternalObservation"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ExternalObservation.classCode">
       <path value="ExternalObservation.classCode"/>
-      <definition value="Element ExternalObservation.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -48,7 +46,6 @@
     </element>
     <element id="ExternalObservation.moodCode">
       <path value="ExternalObservation.moodCode"/>
-      <definition value="Element ExternalObservation.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -75,7 +72,6 @@
     </element>
     <element id="ExternalObservation.id">
       <path value="ExternalObservation.id"/>
-      <definition value="Element ExternalObservation.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -84,7 +80,6 @@
     </element>
     <element id="ExternalObservation.code">
       <path value="ExternalObservation.code"/>
-      <definition value="Element ExternalObservation.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -97,7 +92,6 @@
     </element>
     <element id="ExternalObservation.text">
       <path value="ExternalObservation.text"/>
-      <definition value="Element ExternalObservation.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/ExternalObservation.xml
+++ b/input/resources/ExternalObservation.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OBS"/>
       
@@ -53,6 +54,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>

--- a/input/resources/ExternalProcedure.xml
+++ b/input/resources/ExternalProcedure.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PROC"/>
       <fixedCode value="PROC"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>

--- a/input/resources/ExternalProcedure.xml
+++ b/input/resources/ExternalProcedure.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="ExternalProcedure">
       <path value="ExternalProcedure"/>
-      <definition value="Element ExternalProcedure"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ExternalProcedure.classCode">
       <path value="ExternalProcedure.classCode"/>
-      <definition value="Element ExternalProcedure.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -49,7 +47,6 @@
     </element>
     <element id="ExternalProcedure.moodCode">
       <path value="ExternalProcedure.moodCode"/>
-      <definition value="Element ExternalProcedure.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -76,7 +73,6 @@
     </element>
     <element id="ExternalProcedure.id">
       <path value="ExternalProcedure.id"/>
-      <definition value="Element ExternalProcedure.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -85,7 +81,6 @@
     </element>
     <element id="ExternalProcedure.code">
       <path value="ExternalProcedure.code"/>
-      <definition value="Element ExternalProcedure.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -98,7 +93,6 @@
     </element>
     <element id="ExternalProcedure.text">
       <path value="ExternalProcedure.text"/>
-      <definition value="Element ExternalProcedure.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Guardian.xml
+++ b/input/resources/Guardian.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="GUARD"/>
       <fixedCode value="GUARD"/>

--- a/input/resources/Guardian.xml
+++ b/input/resources/Guardian.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Guardian">
       <path value="Guardian"/>
-      <definition value="Element Guardian"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Guardian.classCode">
       <path value="Guardian.classCode"/>
-      <definition value="Element Guardian.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -59,7 +57,6 @@
     </element>
     <element id="Guardian.id">
       <path value="Guardian.id"/>
-      <definition value="Element Guardian.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -74,7 +71,6 @@
         <valueString value="identifiedBy"/>
       </extension>
       <path value="Guardian.sdtcIdentifiedBy"/>
-      <definition value="Element Guardian.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -83,7 +79,6 @@
     </element>
     <element id="Guardian.code">
       <path value="Guardian.code"/>
-      <definition value="Element Guardian.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -96,7 +91,6 @@
     </element>
     <element id="Guardian.addr">
       <path value="Guardian.addr"/>
-      <definition value="Element Guardian.addr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -105,7 +99,6 @@
     </element>
     <element id="Guardian.telecom">
       <path value="Guardian.telecom"/>
-      <definition value="Element Guardian.telecom"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -114,7 +107,6 @@
     </element>
     <element id="Guardian.guardianPerson">
       <path value="Guardian.guardianPerson"/>
-      <definition value="Element Guardian.guardianPerson"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -123,7 +115,6 @@
     </element>
     <element id="Guardian.guardianOrganization">
       <path value="Guardian.guardianOrganization"/>
-      <definition value="Element Guardian.guardianOrganization"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/HealthCareFacility.xml
+++ b/input/resources/HealthCareFacility.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SDLOC"/>
       <binding>

--- a/input/resources/HealthCareFacility.xml
+++ b/input/resources/HealthCareFacility.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="HealthCareFacility">
       <path value="HealthCareFacility"/>
-      <definition value="Element HealthCareFacility"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="HealthCareFacility.classCode">
       <path value="HealthCareFacility.classCode"/>
-      <definition value="Element HealthCareFacility.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -50,7 +48,6 @@
     </element>
     <element id="HealthCareFacility.id">
       <path value="HealthCareFacility.id"/>
-      <definition value="Element HealthCareFacility.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -65,7 +62,6 @@
         <valueString value="identifiedBy"/>
       </extension>
       <path value="HealthCareFacility.sdtcIdentifiedBy"/>
-      <definition value="Element HealthCareFacility.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -74,7 +70,6 @@
     </element>
     <element id="HealthCareFacility.code">
       <path value="HealthCareFacility.code"/>
-      <definition value="Element HealthCareFacility.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -87,7 +82,6 @@
     </element>
     <element id="HealthCareFacility.location">
       <path value="HealthCareFacility.location"/>
-      <definition value="Element HealthCareFacility.location"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -96,7 +90,6 @@
     </element>
     <element id="HealthCareFacility.serviceProviderOrganization">
       <path value="HealthCareFacility.serviceProviderOrganization"/>
-      <definition value="Element HealthCareFacility.serviceProviderOrganization"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/II.xml
+++ b/input/resources/II.xml
@@ -49,6 +49,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="II.root">

--- a/input/resources/II.xml
+++ b/input/resources/II.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
     <element id="II.displayable">
@@ -75,6 +76,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
   </differential>

--- a/input/resources/II.xml
+++ b/input/resources/II.xml
@@ -61,7 +61,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="id"/>
+        <code value="string"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/oid"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/uuid"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/ruid"/>

--- a/input/resources/II.xml
+++ b/input/resources/II.xml
@@ -60,7 +60,10 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="id"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/oid"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/uuid"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/ruid"/>
       </type>
     </element>
     <element id="II.extension">

--- a/input/resources/INT-POS.xml
+++ b/input/resources/INT-POS.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="INT_POS">
       <path value="INT_POS"/>
-      <definition value="Element INT_POS"/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/input/resources/INT.xml
+++ b/input/resources/INT.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="integer"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/int-simple"/>
       </type>
     </element>
   </differential>

--- a/input/resources/INT.xml
+++ b/input/resources/INT.xml
@@ -25,14 +25,12 @@
   <differential>
     <element id="INT">
       <path value="INT"/>
-      <definition value="Element INT"/>
       <definition value="Integer numbers (-1,0,1,2, 100, 3398129, etc.) are precise numbers that are results of counting and enumerating. Integer numbers are discrete, the set of integers is infinite but countable. No arbitrary limit is imposed on the range of integer numbers. Two NULL flavors are defined for the positive and negative infinity."/>
       <min value="1"/>
       <max value="*"/>
     </element>
     <element id="INT.value">
       <path value="INT.value"/>
-      <definition value="Element INT.value"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>

--- a/input/resources/IVL-INT.xml
+++ b/input/resources/IVL-INT.xml
@@ -19,14 +19,12 @@
   <differential>
     <element id="IVL_INT">
       <path value="IVL_INT"/>
-      <definition value="Element IVL_INT"/>
       <definition value="Interval of integers"/>
       <min value="1"/>
       <max value="*"/>
     </element>
     <element id="IVL_INT.value">
       <path value="IVL_INT.value"/>
-      <definition value="Element IVL_INT.value"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>

--- a/input/resources/IVL-INT.xml
+++ b/input/resources/IVL-INT.xml
@@ -37,6 +37,7 @@
       </base>
       <type>
         <code value="integer"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/int-simple"/>
       </type>
     </element>
     <element id="IVL_INT.low">

--- a/input/resources/IVL-PQ.xml
+++ b/input/resources/IVL-PQ.xml
@@ -19,7 +19,6 @@
   <differential>
     <element id="IVL_PQ">
       <path value="IVL_PQ"/>
-      <definition value="Element IVL_PQ"/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/input/resources/IVL-PQ.xml
+++ b/input/resources/IVL-PQ.xml
@@ -54,6 +54,7 @@
       </base>
       <type>
         <code value="decimal"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/real-simple"/>
       </type>
     </element>
     <element id="IVL_PQ.low">

--- a/input/resources/IVL-PQ.xml
+++ b/input/resources/IVL-PQ.xml
@@ -37,6 +37,7 @@
       </base>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="IVL_PQ.value">

--- a/input/resources/IVL-TS.xml
+++ b/input/resources/IVL-TS.xml
@@ -19,7 +19,6 @@
   <differential>
     <element id="IVL_TS">
       <path value="IVL_TS"/>
-      <definition value="Element IVL_TS"/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/input/resources/IdentifiedBy.xml
+++ b/input/resources/IdentifiedBy.xml
@@ -26,7 +26,6 @@
   <differential>
     <element id="IdentifiedBy">
       <path value="IdentifiedBy"/>
-      <definition value="Element IdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
     </element>

--- a/input/resources/InFulfillmentOf.xml
+++ b/input/resources/InFulfillmentOf.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="InFulfillmentOf">
       <path value="InFulfillmentOf"/>
-      <definition value="Element InFulfillmentOf"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="InFulfillmentOf.typeCode">
       <path value="InFulfillmentOf.typeCode"/>
-      <definition value="Element InFulfillmentOf.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -91,7 +89,6 @@
     </element>
     <element id="InFulfillmentOf.order">
       <path value="InFulfillmentOf.order"/>
-      <definition value="Element InFulfillmentOf.order"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/InFulfillmentOf.xml
+++ b/input/resources/InFulfillmentOf.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="FLFS"/>
       

--- a/input/resources/Informant.xml
+++ b/input/resources/Informant.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="Informant">
       <path value="Informant"/>
-      <definition value="Element Informant"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="Informant.typeCode">
       <path value="Informant.typeCode"/>
-      <definition value="Element Informant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -64,7 +62,6 @@
     </element>
     <element id="Informant.contextControlCode">
       <path value="Informant.contextControlCode"/>
-      <definition value="Element Informant.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -109,7 +106,6 @@
     <!-- TODO: Need to figure out how to constrain assignedEntity and relatedEntity so that only one may be chosen at a time. It is a choice of either assignedEntity and relatedEntity. -->
     <element id="Informant.assignedEntity">
       <path value="Informant.assignedEntity"/>
-      <definition value="Element Informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -118,7 +114,6 @@
     </element>
     <element id="Informant.relatedEntity">
       <path value="Informant.relatedEntity"/>
-      <definition value="Element Informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Informant.xml
+++ b/input/resources/Informant.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="INF"/>
       
@@ -68,6 +70,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="OP"/>
       

--- a/input/resources/InformationRecipient.xml
+++ b/input/resources/InformationRecipient.xml
@@ -27,7 +27,6 @@
   <differential>
     <element id="InformationRecipient">
       <path value="InformationRecipient"/>
-      <definition value="Element InformationRecipient"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -49,7 +48,6 @@
     </element>
     <element id="InformationRecipient.typeCode">
       <path value="InformationRecipient.typeCode"/>
-      <definition value="Element InformationRecipient.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -93,7 +91,6 @@
     </element>
     <element id="InformationRecipient.intendedRecipient">
       <path value="InformationRecipient.intendedRecipient"/>
-      <definition value="Element InformationRecipient.intendedRecipient"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/InformationRecipient.xml
+++ b/input/resources/InformationRecipient.xml
@@ -40,6 +40,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PRCP"/>
       

--- a/input/resources/InfrastructureRoot.xml
+++ b/input/resources/InfrastructureRoot.xml
@@ -27,7 +27,6 @@
   <differential>
     <element id="InfrastructureRoot">
       <path value="InfrastructureRoot"/>
-      <definition value="Element InfrastructureRoot"/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/input/resources/IntendedRecipient.xml
+++ b/input/resources/IntendedRecipient.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ASSIGNED"/>
     </element>

--- a/input/resources/IntendedRecipient.xml
+++ b/input/resources/IntendedRecipient.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="IntendedRecipient">
       <path value="IntendedRecipient"/>
-      <definition value="Element IntendedRecipient"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="IntendedRecipient.classCode">
       <path value="IntendedRecipient.classCode"/>
-      <definition value="Element IntendedRecipient.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -46,7 +44,6 @@
     </element>
     <element id="IntendedRecipient.id">
       <path value="IntendedRecipient.id"/>
-      <definition value="Element IntendedRecipient.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -61,7 +58,6 @@
         <valueString value="identifiedBy"/>
       </extension>
       <path value="IntendedRecipient.sdtcIdentifiedBy"/>
-      <definition value="Element IntendedRecipient.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -70,7 +66,6 @@
     </element>
     <element id="IntendedRecipient.addr">
       <path value="IntendedRecipient.addr"/>
-      <definition value="Element IntendedRecipient.addr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -79,7 +74,6 @@
     </element>
     <element id="IntendedRecipient.telecom">
       <path value="IntendedRecipient.telecom"/>
-      <definition value="Element IntendedRecipient.telecom"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -88,7 +82,6 @@
     </element>
     <element id="IntendedRecipient.informationRecipient">
       <path value="IntendedRecipient.informationRecipient"/>
-      <definition value="Element IntendedRecipient.informationRecipient"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -97,7 +90,6 @@
     </element>
     <element id="IntendedRecipient.receivedOrganization">
       <path value="IntendedRecipient.receivedOrganization"/>
-      <definition value="Element IntendedRecipient.receivedOrganization"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/LabeledDrug.xml
+++ b/input/resources/LabeledDrug.xml
@@ -42,6 +42,7 @@
       </base>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -56,6 +57,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="MMAT"/>
       <fixedCode value="MMAT"/>
@@ -73,6 +75,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="KIND"/>
       <fixedCode value="KIND"/>

--- a/input/resources/LabeledDrug.xml
+++ b/input/resources/LabeledDrug.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="LabeledDrug">
       <path value="LabeledDrug"/>
-      <definition value="Element LabeledDrug"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="LabeledDrug.nullFlavor">
       <path value="LabeledDrug.nullFlavor"/>
-      <definition value="Element LabeledDrug.nullFlavor"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -51,7 +49,6 @@
     </element>
     <element id="LabeledDrug.classCode">
       <path value="LabeledDrug.classCode"/>
-      <definition value="Element LabeledDrug.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -69,7 +66,6 @@
     </element>
     <element id="LabeledDrug.determinerCode">
       <path value="LabeledDrug.determinerCode"/>
-      <definition value="Element LabeledDrug.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -96,7 +92,6 @@
     </element>
     <element id="LabeledDrug.code">
       <path value="LabeledDrug.code"/>
-      <definition value="Element LabeledDrug.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -109,7 +104,6 @@
     </element>
     <element id="LabeledDrug.name">
       <path value="LabeledDrug.name"/>
-      <definition value="Element LabeledDrug.name"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/LanguageCommunication.xml
+++ b/input/resources/LanguageCommunication.xml
@@ -27,7 +27,6 @@
   <differential>
     <element id="LanguageCommunication">
       <path value="LanguageCommunication"/>
-      <definition value="Element LanguageCommunication"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -42,7 +41,6 @@
     </element>
     <element id="LanguageCommunication.languageCode">
       <path value="LanguageCommunication.languageCode"/>
-      <definition value="Element LanguageCommunication.languageCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -55,7 +53,6 @@
     </element>
     <element id="LanguageCommunication.modeCode">
       <path value="LanguageCommunication.modeCode"/>
-      <definition value="Element LanguageCommunication.modeCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -68,7 +65,6 @@
     </element>
     <element id="LanguageCommunication.proficiencyLevelCode">
       <path value="LanguageCommunication.proficiencyLevelCode"/>
-      <definition value="Element LanguageCommunication.proficiencyLevelCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -81,7 +77,6 @@
     </element>
     <element id="LanguageCommunication.preferenceInd">
       <path value="LanguageCommunication.preferenceInd"/>
-      <definition value="Element LanguageCommunication.preferenceInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/LegalAuthenticator.xml
+++ b/input/resources/LegalAuthenticator.xml
@@ -40,6 +40,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="LA"/>
       
@@ -70,6 +72,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="OP"/>
       

--- a/input/resources/LegalAuthenticator.xml
+++ b/input/resources/LegalAuthenticator.xml
@@ -27,7 +27,6 @@
   <differential>
     <element id="LegalAuthenticator">
       <path value="LegalAuthenticator"/>
-      <definition value="Element LegalAuthenticator"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -49,7 +48,6 @@
     </element>
     <element id="LegalAuthenticator.typeCode">
       <path value="LegalAuthenticator.typeCode"/>
-      <definition value="Element LegalAuthenticator.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -66,7 +64,6 @@
     </element>
     <element id="LegalAuthenticator.contextControlCode">
       <path value="LegalAuthenticator.contextControlCode"/>
-      <definition value="Element LegalAuthenticator.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -110,7 +107,6 @@
     </element>
     <element id="LegalAuthenticator.time">
       <path value="LegalAuthenticator.time"/>
-      <definition value="Element LegalAuthenticator.time"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -119,7 +115,6 @@
     </element>
     <element id="LegalAuthenticator.signatureCode">
       <path value="LegalAuthenticator.signatureCode"/>
-      <definition value="Element LegalAuthenticator.signatureCode"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -134,7 +129,6 @@
         <valueString value="signatureText"/>
       </extension>
       <path value="LegalAuthenticator.sdtcSignatureText"/>
-      <definition value="Element LegalAuthenticator.sdtcSignatureText"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -143,7 +137,6 @@
     </element>
     <element id="LegalAuthenticator.assignedEntity">
       <path value="LegalAuthenticator.assignedEntity"/>
-      <definition value="Element LegalAuthenticator.assignedEntity"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/MO.xml
+++ b/input/resources/MO.xml
@@ -46,7 +46,8 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/cda/stds/core/StructureDefinition/REAL"/>
+        <code value="decimal"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/real-simple"/>
       </type>
     </element>
   </differential>

--- a/input/resources/MaintainedEntity.xml
+++ b/input/resources/MaintainedEntity.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="MaintainedEntity">
       <path value="MaintainedEntity"/>
-      <definition value="Element MaintainedEntity"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="MaintainedEntity.classCode">
       <path value="MaintainedEntity.classCode"/>
-      <definition value="Element MaintainedEntity.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -59,7 +57,6 @@
     </element>
     <element id="MaintainedEntity.effectiveTime">
       <path value="MaintainedEntity.effectiveTime"/>
-      <definition value="Element MaintainedEntity.effectiveTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -68,7 +65,6 @@
     </element>
     <element id="MaintainedEntity.maintainingPerson">
       <path value="MaintainedEntity.maintainingPerson"/>
-      <definition value="Element MaintainedEntity.maintainingPerson"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/MaintainedEntity.xml
+++ b/input/resources/MaintainedEntity.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="MNT"/>
       <fixedCode value="MNT"/>

--- a/input/resources/ManufacturedProduct.xml
+++ b/input/resources/ManufacturedProduct.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="MANU"/>
       <fixedCode value="MANU"/>

--- a/input/resources/ManufacturedProduct.xml
+++ b/input/resources/ManufacturedProduct.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="ManufacturedProduct">
       <path value="ManufacturedProduct"/>
-      <definition value="Element ManufacturedProduct"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ManufacturedProduct.classCode">
       <path value="ManufacturedProduct.classCode"/>
-      <definition value="Element ManufacturedProduct.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -51,7 +49,6 @@
     </element>
     <element id="ManufacturedProduct.id">
       <path value="ManufacturedProduct.id"/>
-      <definition value="Element ManufacturedProduct.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -66,7 +63,6 @@
         <valueString value="identifiedBy"/>
       </extension>
       <path value="ManufacturedProduct.sdtcIdentifiedBy"/>
-      <definition value="Element ManufacturedProduct.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -75,7 +71,6 @@
     </element>
     <element id="ManufacturedProduct.manufacturedLabeledDrug">
       <path value="ManufacturedProduct.manufacturedLabeledDrug"/>
-      <definition value="Element ManufacturedProduct.manufacturedLabeledDrug"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -84,7 +79,6 @@
     </element>
     <element id="ManufacturedProduct.manufacturedMaterial">
       <path value="ManufacturedProduct.manufacturedMaterial"/>
-      <definition value="Element ManufacturedProduct.manufacturedMaterial"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -93,7 +87,6 @@
     </element>
     <element id="ManufacturedProduct.manufacturerOrganization">
       <path value="ManufacturedProduct.manufacturerOrganization"/>
-      <definition value="Element ManufacturedProduct.manufacturerOrganization"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Material.xml
+++ b/input/resources/Material.xml
@@ -40,6 +40,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="MMAT"/>
       <fixedCode value="MMAT"/>
@@ -57,6 +58,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="KIND"/>
       <fixedCode value="KIND"/>
@@ -75,6 +77,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>

--- a/input/resources/Material.xml
+++ b/input/resources/Material.xml
@@ -28,13 +28,11 @@
   <differential>
     <element id="Material">
       <path value="Material"/>
-      <definition value="Element Material"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Material.classCode">
       <path value="Material.classCode"/>
-      <definition value="Element Material.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -52,7 +50,6 @@
     </element>
     <element id="Material.determinerCode">
       <path value="Material.determinerCode"/>
-      <definition value="Element Material.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -95,7 +92,6 @@
     </element>
     <element id="Material.code">
       <path value="Material.code"/>
-      <definition value="Element Material.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -108,7 +104,6 @@
     </element>
     <element id="Material.name">
       <path value="Material.name"/>
-      <definition value="Element Material.name"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -117,7 +112,6 @@
     </element>
     <element id="Material.lotNumberText">
       <path value="Material.lotNumberText"/>
-      <definition value="Element Material.lotNumberText"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/NonXMLBody.xml
+++ b/input/resources/NonXMLBody.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="DOCBODY"/>
       <fixedCode value="DOCBODY"/>
@@ -55,6 +56,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>

--- a/input/resources/NonXMLBody.xml
+++ b/input/resources/NonXMLBody.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="NonXMLBody">
       <path value="NonXMLBody"/>
-      <definition value="Element NonXMLBody"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="NonXMLBody.classCode">
       <path value="NonXMLBody.classCode"/>
-      <definition value="Element NonXMLBody.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -50,7 +48,6 @@
     </element>
     <element id="NonXMLBody.moodCode">
       <path value="NonXMLBody.moodCode"/>
-      <definition value="Element NonXMLBody.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -68,7 +65,6 @@
     </element>
     <element id="NonXMLBody.text">
       <path value="NonXMLBody.text"/>
-      <definition value="Element NonXMLBody.text"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -77,7 +73,6 @@
     </element>
     <element id="NonXMLBody.confidentialityCode">
       <path value="NonXMLBody.confidentialityCode"/>
-      <definition value="Element NonXMLBody.confidentialityCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -86,7 +81,6 @@
     </element>
     <element id="NonXMLBody.languageCode">
       <path value="NonXMLBody.languageCode"/>
-      <definition value="Element NonXMLBody.languageCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/ON.xml
+++ b/input/resources/ON.xml
@@ -34,12 +34,10 @@
     </element>
     <element id="ON.family">
       <path value="ON.family"/>
-      <definition value="Element ON.family"/>
       <max value="0"/>
     </element>
     <element id="ON.given">
       <path value="ON.given"/>
-      <definition value="Element ON.given"/>
       <max value="0"/>
     </element>
   </differential>

--- a/input/resources/Observation.xml
+++ b/input/resources/Observation.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Observation">
       <path value="Observation"/>
-      <definition value="Element Observation"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Observation.classCode">
       <path value="Observation.classCode"/>
-      <definition value="Element Observation.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -47,7 +45,6 @@
     </element>
     <element id="Observation.moodCode">
       <path value="Observation.moodCode"/>
-      <definition value="Element Observation.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -58,7 +55,6 @@
     </element>
     <element id="Observation.negationInd">
       <path value="Observation.negationInd"/>
-      <definition value="Element Observation.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -69,7 +65,6 @@
     </element>
     <element id="Observation.realmCode">
       <path value="Observation.realmCode"/>
-      <definition value="Element Observation.realmCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -78,7 +73,6 @@
     </element>
     <element id="Observation.typeId">
       <path value="Observation.typeId"/>
-      <definition value="Element Observation.typeId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -96,7 +90,6 @@
     </element>
     <element id="Observation.id">
       <path value="Observation.id"/>
-      <definition value="Element Observation.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -105,7 +98,6 @@
     </element>
     <element id="Observation.code">
       <path value="Observation.code"/>
-      <definition value="Element Observation.code"/>
       <min value="1"/>
       <max value="1"/>
       <representation value="typeAttr"/>
@@ -119,7 +111,6 @@
     </element>
     <element id="Observation.derivationExpr">
       <path value="Observation.derivationExpr"/>
-      <definition value="Element Observation.derivationExpr"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -128,7 +119,6 @@
     </element>
     <element id="Observation.text">
       <path value="Observation.text"/>
-      <definition value="Element Observation.text"/>
       <min value="0"/>
       <max value="1"/>
       <representation value="typeAttr"/>
@@ -138,7 +128,6 @@
     </element>
     <element id="Observation.statusCode">
       <path value="Observation.statusCode"/>
-      <definition value="Element Observation.statusCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -151,7 +140,6 @@
     </element>
     <element id="Observation.effectiveTime">
       <path value="Observation.effectiveTime"/>
-      <definition value="Element Observation.effectiveTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -160,7 +148,6 @@
     </element>
     <element id="Observation.priorityCode">
       <path value="Observation.priorityCode"/>
-      <definition value="Element Observation.priorityCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -173,7 +160,6 @@
     </element>
     <element id="Observation.repeatNumber">
       <path value="Observation.repeatNumber"/>
-      <definition value="Element Observation.repeatNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -182,7 +168,6 @@
     </element>
     <element id="Observation.languageCode">
       <path value="Observation.languageCode"/>
-      <definition value="Element Observation.languageCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -195,7 +180,6 @@
     </element>
     <element id="Observation.value">
       <path value="Observation.value"/>
-      <definition value="Element Observation.value"/>
       <representation value="typeAttr"/>
       <min value="0"/>
       <max value="*"/>
@@ -268,7 +252,6 @@
     </element>
     <element id="Observation.interpretationCode">
       <path value="Observation.interpretationCode"/>
-      <definition value="Element Observation.interpretationCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -281,7 +264,6 @@
     </element>
     <element id="Observation.methodCode">
       <path value="Observation.methodCode"/>
-      <definition value="Element Observation.methodCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -303,7 +285,6 @@
     </element>
     <element id="Observation.subject">
       <path value="Observation.subject"/>
-      <definition value="Element Observation.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -312,7 +293,6 @@
     </element>
     <element id="Observation.subject.typeCode">
       <path value="Observation.subject.typeCode"/>
-      <definition value="Element Observation.subject.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -330,7 +310,6 @@
     </element>
     <element id="Observation.subject.contextControlCode">
       <path value="Observation.subject.contextControlCode"/>
-      <definition value="Element Observation.subject.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -348,7 +327,6 @@
     </element>
     <element id="Observation.subject.awarenessCode">
       <path value="Observation.subject.awarenessCode"/>
-      <definition value="Element Observation.subject.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -361,7 +339,6 @@
     </element>
     <element id="Observation.subject.relatedSubject">
       <path value="Observation.subject.relatedSubject"/>
-      <definition value="Element Observation.subject.relatedSubject"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -370,7 +347,6 @@
     </element>
     <element id="Observation.specimen">
       <path value="Observation.specimen"/>
-      <definition value="Element Observation.specimen"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -379,7 +355,6 @@
     </element>
     <element id="Observation.performer">
       <path value="Observation.performer"/>
-      <definition value="Element Observation.performer"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -388,7 +363,6 @@
     </element>
     <element id="Observation.author">
       <path value="Observation.author"/>
-      <definition value="Element Observation.author"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -397,7 +371,6 @@
     </element>
     <element id="Observation.informant">
       <path value="Observation.informant"/>
-      <definition value="Element Observation.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -406,7 +379,6 @@
     </element>
     <element id="Observation.informant.typeCode">
       <path value="Observation.informant.typeCode"/>
-      <definition value="Element Observation.informant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -424,7 +396,6 @@
     </element>
     <element id="Observation.informant.contextControlCode">
       <path value="Observation.informant.contextControlCode"/>
-      <definition value="Element Observation.informant.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -442,7 +413,6 @@
     </element>
     <element id="Observation.informant.assignedEntity">
       <path value="Observation.informant.assignedEntity"/>
-      <definition value="Element Observation.informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -451,7 +421,6 @@
     </element>
     <element id="Observation.informant.relatedEntity">
       <path value="Observation.informant.relatedEntity"/>
-      <definition value="Element Observation.informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -460,7 +429,6 @@
     </element>
     <element id="Observation.participant">
       <path value="Observation.participant"/>
-      <definition value="Element Observation.participant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -469,7 +437,6 @@
     </element>
     <element id="Observation.entryRelationship">
       <path value="Observation.entryRelationship"/>
-      <definition value="Element Observation.entryRelationship"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -485,7 +452,6 @@
     </element>
     <element id="Observation.entryRelationship.typeCode">
       <path value="Observation.entryRelationship.typeCode"/>
-      <definition value="Element Observation.entryRelationship.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -497,7 +463,6 @@
     </element>
     <element id="Observation.entryRelationship.inversionInd">
       <path value="Observation.entryRelationship.inversionInd"/>
-      <definition value="Element Observation.entryRelationship.inversionInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -508,7 +473,6 @@
     </element>
     <element id="Observation.entryRelationship.contextConductionInd">
       <path value="Observation.entryRelationship.contextConductionInd"/>
-      <definition value="Element Observation.entryRelationship.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -521,7 +485,6 @@
     </element>
     <element id="Observation.entryRelationship.sequenceNumber">
       <path value="Observation.entryRelationship.sequenceNumber"/>
-      <definition value="Element Observation.entryRelationship.sequenceNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -530,7 +493,6 @@
     </element>
     <element id="Observation.entryRelationship.negationInd">
       <path value="Observation.entryRelationship.negationInd"/>
-      <definition value="Element Observation.entryRelationship.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -541,7 +503,6 @@
     </element>
     <element id="Observation.entryRelationship.seperatableInd">
       <path value="Observation.entryRelationship.seperatableInd"/>
-      <definition value="Element Observation.entryRelationship.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -550,7 +511,6 @@
     </element>
     <element id="Observation.entryRelationship.observation">
       <path value="Observation.entryRelationship.observation"/>
-      <definition value="Element Observation.entryRelationship.observation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -559,7 +519,6 @@
     </element>
     <element id="Observation.entryRelationship.regionOfInterest">
       <path value="Observation.entryRelationship.regionOfInterest"/>
-      <definition value="Element Observation.entryRelationship.regionOfInterest"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -568,7 +527,6 @@
     </element>
     <element id="Observation.entryRelationship.observationMedia">
       <path value="Observation.entryRelationship.observationMedia"/>
-      <definition value="Element Observation.entryRelationship.observationMedia"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -577,7 +535,6 @@
     </element>
     <element id="Observation.entryRelationship.substanceAdministration">
       <path value="Observation.entryRelationship.substanceAdministration"/>
-      <definition value="Element Observation.entryRelationship.substanceAdministration"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -586,7 +543,6 @@
     </element>
     <element id="Observation.entryRelationship.supply">
       <path value="Observation.entryRelationship.supply"/>
-      <definition value="Element Observation.entryRelationship.supply"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -595,7 +551,6 @@
     </element>
     <element id="Observation.entryRelationship.procedure">
       <path value="Observation.entryRelationship.procedure"/>
-      <definition value="Element Observation.entryRelationship.procedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -604,7 +559,6 @@
     </element>
     <element id="Observation.entryRelationship.encounter">
       <path value="Observation.entryRelationship.encounter"/>
-      <definition value="Element Observation.entryRelationship.encounter"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -613,7 +567,6 @@
     </element>
     <element id="Observation.entryRelationship.organizer">
       <path value="Observation.entryRelationship.organizer"/>
-      <definition value="Element Observation.entryRelationship.organizer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -622,7 +575,6 @@
     </element>
     <element id="Observation.entryRelationship.act">
       <path value="Observation.entryRelationship.act"/>
-      <definition value="Element Observation.entryRelationship.act"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -631,7 +583,6 @@
     </element>
     <element id="Observation.reference">
       <path value="Observation.reference"/>
-      <definition value="Element Observation.reference"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -640,7 +591,6 @@
     </element>
     <element id="Observation.reference.typeCode">
       <path value="Observation.reference.typeCode"/>
-      <definition value="Element Observation.reference.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -652,7 +602,6 @@
     </element>
     <element id="Observation.reference.seperatableInd">
       <path value="Observation.reference.seperatableInd"/>
-      <definition value="Element Observation.reference.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -661,7 +610,6 @@
     </element>
     <element id="Observation.reference.externalAct">
       <path value="Observation.reference.externalAct"/>
-      <definition value="Element Observation.reference.externalAct"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -670,7 +618,6 @@
     </element>
     <element id="Observation.reference.externalObservation">
       <path value="Observation.reference.externalObservation"/>
-      <definition value="Element Observation.reference.externalObservation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -679,7 +626,6 @@
     </element>
     <element id="Observation.reference.externalProcedure">
       <path value="Observation.reference.externalProcedure"/>
-      <definition value="Element Observation.reference.externalProcedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -688,7 +634,6 @@
     </element>
     <element id="Observation.reference.externalDocument">
       <path value="Observation.reference.externalDocument"/>
-      <definition value="Element Observation.reference.externalDocument"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -697,7 +642,6 @@
     </element>
     <element id="Observation.precondition">
       <path value="Observation.precondition"/>
-      <definition value="Element Observation.precondition"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -706,7 +650,6 @@
     </element>
     <element id="Observation.referenceRange">
       <path value="Observation.referenceRange"/>
-      <definition value="Element Observation.referenceRange"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -715,7 +658,6 @@
     </element>
     <element id="Observation.referenceRange.typeCode">
       <path value="Observation.referenceRange.typeCode"/>
-      <definition value="Element Observation.referenceRange.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -732,7 +674,6 @@
     </element>
     <element id="Observation.referenceRange.observationRange">
       <path value="Observation.referenceRange.observationRange"/>
-      <definition value="Element Observation.referenceRange.observationRange"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Observation.xml
+++ b/input/resources/Observation.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="Observation.negationInd">
@@ -315,6 +317,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBJ"/>
       <fixedCode value="SBJ"/>
@@ -332,6 +335,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -407,6 +411,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INF"/>
       <fixedCode value="INF"/>
@@ -424,6 +429,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -484,6 +490,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
 
     </element>
@@ -635,6 +642,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
 
     </element>
@@ -709,6 +717,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="REFV"/>
       <fixedCode value="REFV"/>

--- a/input/resources/Observation.xml
+++ b/input/resources/Observation.xml
@@ -64,6 +64,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Observation.realmCode">
@@ -502,6 +503,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Observation.entryRelationship.contextConductionInd">
@@ -512,6 +514,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
 
@@ -533,6 +536,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Observation.entryRelationship.seperatableInd">

--- a/input/resources/ObservationMedia.xml
+++ b/input/resources/ObservationMedia.xml
@@ -49,6 +49,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OBS"/>
       <fixedCode value="OBS"/>
@@ -65,6 +66,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>
@@ -150,6 +152,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBJ"/>
       <fixedCode value="SBJ"/>
@@ -167,6 +170,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -242,6 +246,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INF"/>
       <fixedCode value="INF"/>
@@ -259,6 +264,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -312,6 +318,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>
@@ -463,6 +470,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>

--- a/input/resources/ObservationMedia.xml
+++ b/input/resources/ObservationMedia.xml
@@ -27,13 +27,11 @@
   <differential>
     <element id="ObservationMedia">
       <path value="ObservationMedia"/>
-      <definition value="Element ObservationMedia"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ObservationMedia.ID">
       <path value="ObservationMedia.ID"/>
-      <definition value="Element ObservationMedia.ID"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -44,7 +42,6 @@
     </element>
     <element id="ObservationMedia.classCode">
       <path value="ObservationMedia.classCode"/>
-      <definition value="Element ObservationMedia.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -61,7 +58,6 @@
     </element>
     <element id="ObservationMedia.moodCode">
       <path value="ObservationMedia.moodCode"/>
-      <definition value="Element ObservationMedia.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -78,7 +74,6 @@
     </element>
     <element id="ObservationMedia.realmCode">
       <path value="ObservationMedia.realmCode"/>
-      <definition value="Element ObservationMedia.realmCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -87,7 +82,6 @@
     </element>
     <element id="ObservationMedia.typeId">
       <path value="ObservationMedia.typeId"/>
-      <definition value="Element ObservationMedia.typeId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -105,7 +99,6 @@
     </element>
     <element id="ObservationMedia.id">
       <path value="ObservationMedia.id"/>
-      <definition value="Element ObservationMedia.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -114,7 +107,6 @@
     </element>
     <element id="ObservationMedia.languageCode">
       <path value="ObservationMedia.languageCode"/>
-      <definition value="Element ObservationMedia.languageCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -127,7 +119,6 @@
     </element>
     <element id="ObservationMedia.value">
       <path value="ObservationMedia.value"/>
-      <definition value="Element ObservationMedia.value"/>
       <representation value="typeAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -138,7 +129,6 @@
     </element>
     <element id="ObservationMedia.subject">
       <path value="ObservationMedia.subject"/>
-      <definition value="Element ObservationMedia.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -147,7 +137,6 @@
     </element>
     <element id="ObservationMedia.subject.typeCode">
       <path value="ObservationMedia.subject.typeCode"/>
-      <definition value="Element ObservationMedia.subject.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -165,7 +154,6 @@
     </element>
     <element id="ObservationMedia.subject.contextControlCode">
       <path value="ObservationMedia.subject.contextControlCode"/>
-      <definition value="Element ObservationMedia.subject.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -183,7 +171,6 @@
     </element>
     <element id="ObservationMedia.subject.awarenessCode">
       <path value="ObservationMedia.subject.awarenessCode"/>
-      <definition value="Element ObservationMedia.subject.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -196,7 +183,6 @@
     </element>
     <element id="ObservationMedia.subject.relatedSubject">
       <path value="ObservationMedia.subject.relatedSubject"/>
-      <definition value="Element ObservationMedia.subject.relatedSubject"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -205,7 +191,6 @@
     </element>
     <element id="ObservationMedia.specimen">
       <path value="ObservationMedia.specimen"/>
-      <definition value="Element ObservationMedia.specimen"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -214,7 +199,6 @@
     </element>
     <element id="ObservationMedia.performer">
       <path value="ObservationMedia.performer"/>
-      <definition value="Element ObservationMedia.performer"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -223,7 +207,6 @@
     </element>
     <element id="ObservationMedia.author">
       <path value="ObservationMedia.author"/>
-      <definition value="Element ObservationMedia.author"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -232,7 +215,6 @@
     </element>
     <element id="ObservationMedia.informant">
       <path value="ObservationMedia.informant"/>
-      <definition value="Element ObservationMedia.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -241,7 +223,6 @@
     </element>
     <element id="ObservationMedia.informant.typeCode">
       <path value="ObservationMedia.informant.typeCode"/>
-      <definition value="Element ObservationMedia.informant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -259,7 +240,6 @@
     </element>
     <element id="ObservationMedia.informant.contextControlCode">
       <path value="ObservationMedia.informant.contextControlCode"/>
-      <definition value="Element ObservationMedia.informant.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -277,7 +257,6 @@
     </element>
     <element id="ObservationMedia.informant.assignedEntity">
       <path value="ObservationMedia.informant.assignedEntity"/>
-      <definition value="Element ObservationMedia.informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -286,7 +265,6 @@
     </element>
     <element id="ObservationMedia.informant.relatedEntity">
       <path value="ObservationMedia.informant.relatedEntity"/>
-      <definition value="Element ObservationMedia.informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -295,7 +273,6 @@
     </element>
     <element id="ObservationMedia.participant">
       <path value="ObservationMedia.participant"/>
-      <definition value="Element ObservationMedia.participant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -304,7 +281,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship">
       <path value="ObservationMedia.entryRelationship"/>
-      <definition value="Element ObservationMedia.entryRelationship"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -313,7 +289,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.typeCode">
       <path value="ObservationMedia.entryRelationship.typeCode"/>
-      <definition value="Element ObservationMedia.entryRelationship.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -325,7 +300,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.inversionInd">
       <path value="ObservationMedia.entryRelationship.inversionInd"/>
-      <definition value="Element ObservationMedia.entryRelationship.inversionInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -336,7 +310,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.contextConductionInd">
       <path value="ObservationMedia.entryRelationship.contextConductionInd"/>
-      <definition value="Element ObservationMedia.entryRelationship.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -349,7 +322,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.sequenceNumber">
       <path value="ObservationMedia.entryRelationship.sequenceNumber"/>
-      <definition value="Element ObservationMedia.entryRelationship.sequenceNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -358,7 +330,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.negationInd">
       <path value="ObservationMedia.entryRelationship.negationInd"/>
-      <definition value="Element ObservationMedia.entryRelationship.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -369,7 +340,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.seperatableInd">
       <path value="ObservationMedia.entryRelationship.seperatableInd"/>
-      <definition value="Element ObservationMedia.entryRelationship.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -378,7 +348,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.observation">
       <path value="ObservationMedia.entryRelationship.observation"/>
-      <definition value="Element ObservationMedia.entryRelationship.observation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -387,7 +356,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.regionOfInterest">
       <path value="ObservationMedia.entryRelationship.regionOfInterest"/>
-      <definition value="Element ObservationMedia.entryRelationship.regionOfInterest"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -396,7 +364,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.observationMedia">
       <path value="ObservationMedia.entryRelationship.observationMedia"/>
-      <definition value="Element ObservationMedia.entryRelationship.observationMedia"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -405,7 +372,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.substanceAdministration">
       <path value="ObservationMedia.entryRelationship.substanceAdministration"/>
-      <definition value="Element ObservationMedia.entryRelationship.substanceAdministration"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -414,7 +380,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.supply">
       <path value="ObservationMedia.entryRelationship.supply"/>
-      <definition value="Element ObservationMedia.entryRelationship.supply"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -423,7 +388,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.procedure">
       <path value="ObservationMedia.entryRelationship.procedure"/>
-      <definition value="Element ObservationMedia.entryRelationship.procedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -432,7 +396,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.encounter">
       <path value="ObservationMedia.entryRelationship.encounter"/>
-      <definition value="Element ObservationMedia.entryRelationship.encounter"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -441,7 +404,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.organizer">
       <path value="ObservationMedia.entryRelationship.organizer"/>
-      <definition value="Element ObservationMedia.entryRelationship.organizer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -450,7 +412,6 @@
     </element>
     <element id="ObservationMedia.entryRelationship.act">
       <path value="ObservationMedia.entryRelationship.act"/>
-      <definition value="Element ObservationMedia.entryRelationship.act"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -459,7 +420,6 @@
     </element>
     <element id="ObservationMedia.reference">
       <path value="ObservationMedia.reference"/>
-      <definition value="Element ObservationMedia.reference"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -468,7 +428,6 @@
     </element>
     <element id="ObservationMedia.reference.typeCode">
       <path value="ObservationMedia.reference.typeCode"/>
-      <definition value="Element ObservationMedia.reference.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -480,7 +439,6 @@
     </element>
     <element id="ObservationMedia.reference.seperatableInd">
       <path value="ObservationMedia.reference.seperatableInd"/>
-      <definition value="Element ObservationMedia.reference.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -489,7 +447,6 @@
     </element>
     <element id="ObservationMedia.reference.externalAct">
       <path value="ObservationMedia.reference.externalAct"/>
-      <definition value="Element ObservationMedia.reference.externalAct"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -498,7 +455,6 @@
     </element>
     <element id="ObservationMedia.reference.externalObservation">
       <path value="ObservationMedia.reference.externalObservation"/>
-      <definition value="Element ObservationMedia.reference.externalObservation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -507,7 +463,6 @@
     </element>
     <element id="ObservationMedia.reference.externalProcedure">
       <path value="ObservationMedia.reference.externalProcedure"/>
-      <definition value="Element ObservationMedia.reference.externalProcedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -516,7 +471,6 @@
     </element>
     <element id="ObservationMedia.reference.externalDocument">
       <path value="ObservationMedia.reference.externalDocument"/>
-      <definition value="Element ObservationMedia.reference.externalDocument"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -525,7 +479,6 @@
     </element>
     <element id="ObservationMedia.precondition">
       <path value="ObservationMedia.precondition"/>
-      <definition value="Element ObservationMedia.precondition"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/ObservationMedia.xml
+++ b/input/resources/ObservationMedia.xml
@@ -330,6 +330,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="ObservationMedia.entryRelationship.contextConductionInd">
@@ -340,6 +341,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
       
@@ -361,6 +363,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="ObservationMedia.entryRelationship.seperatableInd">

--- a/input/resources/ObservationMedia.xml
+++ b/input/resources/ObservationMedia.xml
@@ -38,7 +38,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="id"/>
       </type>
     </element>
     <element id="ObservationMedia.classCode">

--- a/input/resources/ObservationMedia.xml
+++ b/input/resources/ObservationMedia.xml
@@ -39,6 +39,7 @@
       <max value="1"/>
       <type>
         <code value="id"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/xs-ID"/>
       </type>
     </element>
     <element id="ObservationMedia.classCode">

--- a/input/resources/ObservationRange.xml
+++ b/input/resources/ObservationRange.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="ObservationRange">
       <path value="ObservationRange"/>
-      <definition value="Element ObservationRange"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ObservationRange.classCode">
       <path value="ObservationRange.classCode"/>
-      <definition value="Element ObservationRange.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -42,7 +40,6 @@
     </element>
     <element id="ObservationRange.moodCode">
       <path value="ObservationRange.moodCode"/>
-      <definition value="Element ObservationRange.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -69,7 +66,6 @@
     </element>
     <element id="ObservationRange.code">
       <path value="ObservationRange.code"/>
-      <definition value="Element ObservationRange.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -82,7 +78,6 @@
     </element>
     <element id="ObservationRange.text">
       <path value="ObservationRange.text"/>
-      <definition value="Element ObservationRange.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -91,7 +86,6 @@
     </element>
     <element id="ObservationRange.value">
       <path value="ObservationRange.value"/>
-      <definition value="Element ObservationRange.value"/>
       <representation value="typeAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -161,7 +155,6 @@
     </element>
     <element id="ObservationRange.interpretationCode">
       <path value="ObservationRange.interpretationCode"/>
-      <definition value="Element ObservationRange.interpretationCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/ObservationRange.xml
+++ b/input/resources/ObservationRange.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OBS"/>
       
@@ -47,6 +48,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN.CRT"/>
       <fixedCode value="EVN.CRT"/>

--- a/input/resources/Order.xml
+++ b/input/resources/Order.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="Order">
       <path value="Order"/>
-      <definition value="Element Order"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Order.classCode">
       <path value="Order.classCode"/>
-      <definition value="Element Order.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -47,7 +45,6 @@
     </element>
     <element id="Order.moodCode">
       <path value="Order.moodCode"/>
-      <definition value="Element Order.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -74,7 +71,6 @@
     </element>
     <element id="Order.id">
       <path value="Order.id"/>
-      <definition value="Element Order.id"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -83,7 +79,6 @@
     </element>
     <element id="Order.code">
       <path value="Order.code"/>
-      <definition value="Element Order.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -96,7 +91,6 @@
     </element>
     <element id="Order.priorityCode">
       <path value="Order.priorityCode"/>
-      <definition value="Element Order.priorityCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Order.xml
+++ b/input/resources/Order.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ACT"/>
       <binding>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="RQO"/>
       <fixedCode value="RQO"/>

--- a/input/resources/Organization.xml
+++ b/input/resources/Organization.xml
@@ -40,6 +40,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ORG"/>
       <fixedCode value="ORG"/>
@@ -71,6 +73,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INSTANCE"/>
       <fixedCode value="INSTANCE"/>

--- a/input/resources/Organization.xml
+++ b/input/resources/Organization.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Organization">
       <path value="Organization"/>
-      <definition value="Element Organization"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Organization.nullFlavor">
       <path value="Organization.nullFlavor"/>
-      <definition value="Element Organization.nullFlavor"/>
       <representation value="xmlAttr"/>
       <label value="Exceptional Value Detail"/>
       <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
@@ -49,7 +47,6 @@
     </element>
     <element id="Organization.classCode">
       <path value="Organization.classCode"/>
-      <definition value="Element Organization.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -67,7 +64,6 @@
     </element>
     <element id="Organization.determinerCode">
       <path value="Organization.determinerCode"/>
-      <definition value="Element Organization.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -85,7 +81,6 @@
     </element>
     <element id="Organization.realmCode">
       <path value="Organization.realmCode"/>
-      <definition value="Element Organization.realmCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -94,7 +89,6 @@
     </element>
     <element id="Organization.typeId">
       <path value="Organization.typeId"/>
-      <definition value="Element Organization.typeId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -112,7 +106,6 @@
     </element>
     <element id="Organization.id">
       <path value="Organization.id"/>
-      <definition value="Element Organization.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -121,7 +114,6 @@
     </element>
     <element id="Organization.name">
       <path value="Organization.name"/>
-      <definition value="Element Organization.name"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -130,7 +122,6 @@
     </element>
     <element id="Organization.telecom">
       <path value="Organization.telecom"/>
-      <definition value="Element Organization.telecom"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -139,7 +130,6 @@
     </element>
     <element id="Organization.addr">
       <path value="Organization.addr"/>
-      <definition value="Element Organization.addr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -148,7 +138,6 @@
     </element>
     <element id="Organization.standardIndustryClassCode">
       <path value="Organization.standardIndustryClassCode"/>
-      <definition value="Element Organization.standardIndustryClassCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -161,7 +150,6 @@
     </element>
     <element id="Organization.asOrganizationPartOf">
       <path value="Organization.asOrganizationPartOf"/>
-      <definition value="Element Organization.asOrganizationPartOf"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/OrganizationPartOf.xml
+++ b/input/resources/OrganizationPartOf.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PART"/>
       <fixedCode value="PART"/>

--- a/input/resources/OrganizationPartOf.xml
+++ b/input/resources/OrganizationPartOf.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="OrganizationPartOf">
       <path value="OrganizationPartOf"/>
-      <definition value="Element OrganizationPartOf"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="OrganizationPartOf.classCode">
       <path value="OrganizationPartOf.classCode"/>
-      <definition value="Element OrganizationPartOf.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -51,7 +49,6 @@
     </element>
     <element id="OrganizationPartOf.id">
       <path value="OrganizationPartOf.id"/>
-      <definition value="Element OrganizationPartOf.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -75,7 +72,6 @@
     </element>
     <element id="OrganizationPartOf.code">
       <path value="OrganizationPartOf.code"/>
-      <definition value="Element OrganizationPartOf.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -88,7 +84,6 @@
     </element>
     <element id="OrganizationPartOf.statusCode">
       <path value="OrganizationPartOf.statusCode"/>
-      <definition value="Element OrganizationPartOf.statusCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -97,7 +92,6 @@
     </element>
     <element id="OrganizationPartOf.effectiveTime">
       <path value="OrganizationPartOf.effectiveTime"/>
-      <definition value="Element OrganizationPartOf.effectiveTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -106,7 +100,6 @@
     </element>
     <element id="OrganizationPartOf.wholeOrganization">
       <path value="OrganizationPartOf.wholeOrganization"/>
-      <definition value="Element OrganizationPartOf.wholeOrganization"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Organizer.xml
+++ b/input/resources/Organizer.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>
@@ -150,6 +152,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBJ"/>
       <fixedCode value="SBJ"/>
@@ -166,6 +169,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -240,6 +244,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INF"/>
       <fixedCode value="INF"/>
@@ -256,6 +261,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -308,6 +314,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>
@@ -382,6 +389,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="COMP"/>
       <fixedCode value="COMP"/>

--- a/input/resources/Organizer.xml
+++ b/input/resources/Organizer.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Organizer">
       <path value="Organizer"/>
-      <definition value="Element Organizer"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Organizer.classCode">
       <path value="Organizer.classCode"/>
-      <definition value="Element Organizer.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -47,7 +45,6 @@
     </element>
     <element id="Organizer.moodCode">
       <path value="Organizer.moodCode"/>
-      <definition value="Element Organizer.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -64,7 +61,6 @@
     </element>
     <element id="Organizer.realmCode">
       <path value="Organizer.realmCode"/>
-      <definition value="Element Organizer.realmCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -73,7 +69,6 @@
     </element>
     <element id="Organizer.typeId">
       <path value="Organizer.typeId"/>
-      <definition value="Element Organizer.typeId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -82,7 +77,6 @@
     </element>
     <element id="Organizer.templateId">
       <path value="Organizer.templateId"/>
-      <definition value="Element Organizer.templateId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -92,7 +86,6 @@
     </element>
     <element id="Organizer.id">
       <path value="Organizer.id"/>
-      <definition value="Element Organizer.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -101,7 +94,6 @@
     </element>
     <element id="Organizer.code">
       <path value="Organizer.code"/>
-      <definition value="Element Organizer.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -114,7 +106,6 @@
     </element>
     <element id="Organizer.statusCode">
       <path value="Organizer.statusCode"/>
-      <definition value="Element Organizer.statusCode"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -127,7 +118,6 @@
     </element>
     <element id="Organizer.effectiveTime">
       <path value="Organizer.effectiveTime"/>
-      <definition value="Element Organizer.effectiveTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -137,7 +127,6 @@
     
     <element id="Organizer.subject">
       <path value="Organizer.subject"/>
-      <definition value="Element Organizer.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -146,7 +135,6 @@
     </element>
     <element id="Organizer.subject.typeCode">
       <path value="Organizer.subject.typeCode"/>
-      <definition value="Element Organizer.subject.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -163,7 +151,6 @@
     </element>
     <element id="Organizer.subject.contextControlCode">
       <path value="Organizer.subject.contextControlCode"/>
-      <definition value="Element Organizer.subject.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -180,7 +167,6 @@
     </element>
     <element id="Organizer.subject.awarenessCode">
       <path value="Organizer.subject.awarenessCode"/>
-      <definition value="Element Organizer.subject.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -193,7 +179,6 @@
     </element>
     <element id="Organizer.subject.relatedSubject">
       <path value="Organizer.subject.relatedSubject"/>
-      <definition value="Element Organizer.subject.relatedSubject"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -202,7 +187,6 @@
     </element>
     <element id="Organizer.specimen">
       <path value="Organizer.specimen"/>
-      <definition value="Element Organizer.specimen"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -211,7 +195,6 @@
     </element>
     <element id="Organizer.performer">
       <path value="Organizer.performer"/>
-      <definition value="Element Organizer.performer"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -220,7 +203,6 @@
     </element>
     <element id="Organizer.author">
       <path value="Organizer.author"/>
-      <definition value="Element Organizer.author"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -229,7 +211,6 @@
     </element>
     <element id="Organizer.informant">
       <path value="Organizer.informant"/>
-      <definition value="Element Organizer.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -238,7 +219,6 @@
     </element>
     <element id="Organizer.informant.typeCode">
       <path value="Organizer.informant.typeCode"/>
-      <definition value="Element Organizer.informant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -255,7 +235,6 @@
     </element>
     <element id="Organizer.informant.contextControlCode">
       <path value="Organizer.informant.contextControlCode"/>
-      <definition value="Element Organizer.informant.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -272,7 +251,6 @@
     </element>
     <element id="Organizer.informant.assignedEntity">
       <path value="Organizer.informant.assignedEntity"/>
-      <definition value="Element Organizer.informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -281,7 +259,6 @@
     </element>
     <element id="Organizer.informant.relatedEntity">
       <path value="Organizer.informant.relatedEntity"/>
-      <definition value="Element Organizer.informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -290,7 +267,6 @@
     </element>
     <element id="Organizer.participant">
       <path value="Organizer.participant"/>
-      <definition value="Element Organizer.participant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -299,7 +275,6 @@
     </element>
     <element id="Organizer.reference">
       <path value="Organizer.reference"/>
-      <definition value="Element Organizer.reference"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -308,7 +283,6 @@
     </element>
     <element id="Organizer.reference.typeCode">
       <path value="Organizer.reference.typeCode"/>
-      <definition value="Element Organizer.reference.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -320,7 +294,6 @@
     </element>
     <element id="Organizer.reference.seperatableInd">
       <path value="Organizer.reference.seperatableInd"/>
-      <definition value="Element Organizer.reference.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -329,7 +302,6 @@
     </element>
     <element id="Organizer.reference.externalAct">
       <path value="Organizer.reference.externalAct"/>
-      <definition value="Element Organizer.reference.externalAct"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -338,7 +310,6 @@
     </element>
     <element id="Organizer.reference.externalObservation">
       <path value="Organizer.reference.externalObservation"/>
-      <definition value="Element Organizer.reference.externalObservation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -347,7 +318,6 @@
     </element>
     <element id="Organizer.reference.externalProcedure">
       <path value="Organizer.reference.externalProcedure"/>
-      <definition value="Element Organizer.reference.externalProcedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -356,7 +326,6 @@
     </element>
     <element id="Organizer.reference.externalDocument">
       <path value="Organizer.reference.externalDocument"/>
-      <definition value="Element Organizer.reference.externalDocument"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -365,7 +334,6 @@
     </element>
     <element id="Organizer.precondition">
       <path value="Organizer.precondition"/>
-      <definition value="Element Organizer.precondition"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -374,7 +342,6 @@
     </element>
     <element id="Organizer.component">
       <path value="Organizer.component"/>
-      <definition value="Element Organizer.component"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -383,7 +350,6 @@
     </element>
     <element id="Organizer.component.typeCode">
       <path value="Organizer.component.typeCode"/>
-      <definition value="Element Organizer.component.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -396,7 +362,6 @@
     </element>
     <element id="Organizer.component.contextConductionInd">
       <path value="Organizer.component.contextConductionInd"/>
-      <definition value="Element Organizer.component.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -408,7 +373,6 @@
     </element>
     <element id="Organizer.component.sequenceNumber">
       <path value="Organizer.component.sequenceNumber"/>
-      <definition value="Element Organizer.component.sequenceNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -417,7 +381,6 @@
     </element>
     <element id="Organizer.component.seperatableInd">
       <path value="Organizer.component.seperatableInd"/>
-      <definition value="Element Organizer.component.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -426,7 +389,6 @@
     </element>
     <element id="Organizer.component.observation">
       <path value="Organizer.component.observation"/>
-      <definition value="Element Organizer.component.observation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -435,7 +397,6 @@
     </element>
     <element id="Organizer.component.regionOfInterest">
       <path value="Organizer.component.regionOfInterest"/>
-      <definition value="Element Organizer.component.regionOfInterest"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -444,7 +405,6 @@
     </element>
     <element id="Organizer.component.observationMedia">
       <path value="Organizer.component.observationMedia"/>
-      <definition value="Element Organizer.component.observationMedia"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -453,7 +413,6 @@
     </element>
     <element id="Organizer.component.substanceAdministration">
       <path value="Organizer.component.substanceAdministration"/>
-      <definition value="Element Organizer.component.substanceAdministration"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -462,7 +421,6 @@
     </element>
     <element id="Organizer.component.supply">
       <path value="Organizer.component.supply"/>
-      <definition value="Element Organizer.component.supply"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -471,7 +429,6 @@
     </element>
     <element id="Organizer.component.procedure">
       <path value="Organizer.component.procedure"/>
-      <definition value="Element Organizer.component.procedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -480,7 +437,6 @@
     </element>
     <element id="Organizer.component.encounter">
       <path value="Organizer.component.encounter"/>
-      <definition value="Element Organizer.component.encounter"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -489,7 +445,6 @@
     </element>
     <element id="Organizer.component.organizer">
       <path value="Organizer.component.organizer"/>
-      <definition value="Element Organizer.component.organizer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -498,7 +453,6 @@
     </element>
     <element id="Organizer.component.act">
       <path value="Organizer.component.act"/>
-      <definition value="Element Organizer.component.act"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Organizer.xml
+++ b/input/resources/Organizer.xml
@@ -402,6 +402,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
     </element>

--- a/input/resources/PIVL-TS.xml
+++ b/input/resources/PIVL-TS.xml
@@ -58,6 +58,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="PIVL_TS.institutionSpecified">

--- a/input/resources/PIVL-TS.xml
+++ b/input/resources/PIVL-TS.xml
@@ -70,6 +70,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
   </differential>

--- a/input/resources/PN.xml
+++ b/input/resources/PN.xml
@@ -34,7 +34,6 @@
     </element>
     <element id="PN.use">
       <path value="PN.use"/>
-      <definition value="Element PN.use"/>
       <binding>
         <strength value="required"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-PersonNameUse"/>

--- a/input/resources/PQ.xml
+++ b/input/resources/PQ.xml
@@ -31,7 +31,6 @@
     </element>
     <element id="PQ.inclusive">
       <path value="PQ.inclusive"/>
-      <definition value="Element PQ.inclusive"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>

--- a/input/resources/PQ.xml
+++ b/input/resources/PQ.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="PQ.unit">

--- a/input/resources/PQ.xml
+++ b/input/resources/PQ.xml
@@ -62,6 +62,7 @@
       <max value="1"/>
       <type>
         <code value="decimal"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/real-simple"/>
       </type>
     </element>
     <element id="PQ.translation">

--- a/input/resources/PQ.xml
+++ b/input/resources/PQ.xml
@@ -48,6 +48,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="1"/>
     </element>

--- a/input/resources/PQR.xml
+++ b/input/resources/PQR.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="decimal"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/real-simple"/>
       </type>
     </element>
   </differential>

--- a/input/resources/ParentDocument.xml
+++ b/input/resources/ParentDocument.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="ParentDocument">
       <path value="ParentDocument"/>
-      <definition value="Element ParentDocument"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ParentDocument.classCode">
       <path value="ParentDocument.classCode"/>
-      <definition value="Element ParentDocument.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -49,7 +47,6 @@
     </element>
     <element id="ParentDocument.moodCode">
       <path value="ParentDocument.moodCode"/>
-      <definition value="Element ParentDocument.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -76,7 +73,6 @@
     </element>
     <element id="ParentDocument.id">
       <path value="ParentDocument.id"/>
-      <definition value="Element ParentDocument.id"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -85,7 +81,6 @@
     </element>
     <element id="ParentDocument.code">
       <path value="ParentDocument.code"/>
-      <definition value="Element ParentDocument.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -98,7 +93,6 @@
     </element>
     <element id="ParentDocument.text">
       <path value="ParentDocument.text"/>
-      <definition value="Element ParentDocument.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -107,7 +101,6 @@
     </element>
     <element id="ParentDocument.setId">
       <path value="ParentDocument.setId"/>
-      <definition value="Element ParentDocument.setId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -116,7 +109,6 @@
     </element>
     <element id="ParentDocument.versionNumber">
       <path value="ParentDocument.versionNumber"/>
-      <definition value="Element ParentDocument.versionNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/ParentDocument.xml
+++ b/input/resources/ParentDocument.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="DOCCLIN"/>
       <fixedCode value="DOCCLIN"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>

--- a/input/resources/Participant1.xml
+++ b/input/resources/Participant1.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="Participant1">
       <path value="Participant1"/>
-      <definition value="Element Participant1"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="Participant1.typeCode">
       <path value="Participant1.typeCode"/>
-      <definition value="Element Participant1.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -62,7 +60,6 @@
     </element>
     <element id="Participant1.contextControlCode">
       <path value="Participant1.contextControlCode"/>
-      <definition value="Element Participant1.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -106,7 +103,6 @@
     </element>
     <element id="Participant1.functionCode">
       <path value="Participant1.functionCode"/>
-      <definition value="Element Participant1.functionCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -116,7 +112,6 @@
     </element>
     <element id="Participant1.time">
       <path value="Participant1.time"/>
-      <definition value="Element Participant1.time"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -126,7 +121,6 @@
     </element>
     <element id="Participant1.associatedEntity">
       <path value="Participant1.associatedEntity"/>
-      <definition value="Element Participant1.associatedEntity"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Participant1.xml
+++ b/input/resources/Participant1.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -66,6 +68,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="OP"/>
       

--- a/input/resources/Participant2.xml
+++ b/input/resources/Participant2.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="Participant2">
       <path value="Participant2"/>
-      <definition value="Element Participant2"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="Participant2.typeCode">
       <path value="Participant2.typeCode"/>
-      <definition value="Element Participant2.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -62,7 +60,6 @@
     </element>
     <element id="Participant2.contextControlCode">
       <path value="Participant2.contextControlCode"/>
-      <definition value="Element Participant2.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -111,7 +108,6 @@
         <valueString value="functionCode"/>
       </extension>
       <path value="Participant2.sdtcFunctionCode"/>
-      <definition value="Element Participant2.sdtcFunctionCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -120,7 +116,6 @@
     </element>
     <element id="Participant2.time">
       <path value="Participant2.time"/>
-      <definition value="Element Participant2.time"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -129,7 +124,6 @@
     </element>
     <element id="Participant2.awarenessCode">
       <path value="Participant2.awarenessCode"/>
-      <definition value="Element Participant2.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -138,7 +132,6 @@
     </element>
     <element id="Participant2.participantRole">
       <path value="Participant2.participantRole"/>
-      <definition value="Element Participant2.participantRole"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Participant2.xml
+++ b/input/resources/Participant2.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -66,6 +68,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="OP"/>
       <binding>

--- a/input/resources/ParticipantRole.xml
+++ b/input/resources/ParticipantRole.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ROL"/>
       

--- a/input/resources/ParticipantRole.xml
+++ b/input/resources/ParticipantRole.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="ParticipantRole">
       <path value="ParticipantRole"/>
-      <definition value="Element ParticipantRole"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ParticipantRole.classCode">
       <path value="ParticipantRole.classCode"/>
-      <definition value="Element ParticipantRole.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -51,7 +49,6 @@
     </element>
     <element id="ParticipantRole.id">
       <path value="ParticipantRole.id"/>
-      <definition value="Element ParticipantRole.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -66,7 +63,6 @@
         <valueString value="identifiedBy"/>
       </extension>
       <path value="ParticipantRole.sdtcIdentifiedBy"/>
-      <definition value="Element ParticipantRole.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -75,7 +71,6 @@
     </element>
     <element id="ParticipantRole.code">
       <path value="ParticipantRole.code"/>
-      <definition value="Element ParticipantRole.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -88,7 +83,6 @@
     </element>
     <element id="ParticipantRole.addr">
       <path value="ParticipantRole.addr"/>
-      <definition value="Element ParticipantRole.addr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -97,7 +91,6 @@
     </element>
     <element id="ParticipantRole.telecom">
       <path value="ParticipantRole.telecom"/>
-      <definition value="Element ParticipantRole.telecom"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -106,7 +99,6 @@
     </element>
     <element id="ParticipantRole.playingDevice">
       <path value="ParticipantRole.playingDevice"/>
-      <definition value="Element ParticipantRole.playingDevice"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -115,7 +107,6 @@
     </element>
     <element id="ParticipantRole.playingEntity">
       <path value="ParticipantRole.playingEntity"/>
-      <definition value="Element ParticipantRole.playingEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -124,7 +115,6 @@
     </element>
     <element id="ParticipantRole.scopingEntity">
       <path value="ParticipantRole.scopingEntity"/>
-      <definition value="Element ParticipantRole.scopingEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Patient.xml
+++ b/input/resources/Patient.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PSN"/>
       <fixedCode value="PSN"/>
@@ -55,6 +56,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INSTANCE"/>
       <fixedCode value="INSTANCE"/>

--- a/input/resources/Patient.xml
+++ b/input/resources/Patient.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Patient">
       <path value="Patient"/>
-      <definition value="Element Patient"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Patient.classCode">
       <path value="Patient.classCode"/>
-      <definition value="Element Patient.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -50,7 +48,6 @@
     </element>
     <element id="Patient.determinerCode">
       <path value="Patient.determinerCode"/>
-      <definition value="Element Patient.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -77,7 +74,6 @@
     </element>
     <element id="Patient.id">
       <path value="Patient.id"/>
-      <definition value="Element Patient.id"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -86,7 +82,6 @@
     </element>
     <element id="Patient.name">
       <path value="Patient.name"/>
-      <definition value="Element Patient.name"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -101,7 +96,6 @@
         <valueString value="desc"/>
       </extension>
       <path value="Patient.sdtcDesc"/>
-      <definition value="Element Patient.sdtcDesc"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -110,7 +104,6 @@
     </element>
     <element id="Patient.administrativeGenderCode">
       <path value="Patient.administrativeGenderCode"/>
-      <definition value="Element Patient.administrativeGenderCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -123,7 +116,6 @@
     </element>
     <element id="Patient.birthTime">
       <path value="Patient.birthTime"/>
-      <definition value="Element Patient.birthTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -138,7 +130,6 @@
         <valueString value="deceasedInd"/>
       </extension>
       <path value="Patient.sdtcDeceasedInd"/>
-      <definition value="Element Patient.sdtcDeceasedInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -153,7 +144,6 @@
         <valueString value="deceasedTime"/>
       </extension>
       <path value="Patient.sdtcDeceasedTime"/>
-      <definition value="Element Patient.sdtcDeceasedTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -168,7 +158,6 @@
         <valueString value="multipleBirthInd"/>
       </extension>
       <path value="Patient.sdtcMultipleBirthInd"/>
-      <definition value="Element Patient.sdtcMultipleBirthInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -183,7 +172,6 @@
         <valueString value="multipleBirthOrderNumber"/>
       </extension>
       <path value="Patient.sdtcMultipleBirthOrderNumber"/>
-      <definition value="Element Patient.sdtcMultipleBirthOrderNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -192,7 +180,6 @@
     </element>
     <element id="Patient.maritalStatusCode">
       <path value="Patient.maritalStatusCode"/>
-      <definition value="Element Patient.maritalStatusCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -205,7 +192,6 @@
     </element>
     <element id="Patient.religiousAffiliationCode">
       <path value="Patient.religiousAffiliationCode"/>
-      <definition value="Element Patient.religiousAffiliationCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -218,7 +204,6 @@
     </element>
     <element id="Patient.raceCode">
       <path value="Patient.raceCode"/>
-      <definition value="Element Patient.raceCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -237,7 +222,6 @@
         <valueString value="raceCode"/>
       </extension>
       <path value="Patient.sdtcRaceCode"/>
-      <definition value="Element Patient.sdtcRaceCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -250,7 +234,6 @@
     </element>
     <element id="Patient.ethnicGroupCode">
       <path value="Patient.ethnicGroupCode"/>
-      <definition value="Element Patient.ethnicGroupCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -269,7 +252,6 @@
         <valueString value="ethnicGroupCode"/>
       </extension>
       <path value="Patient.sdtcEthnicGroupCode"/>
-      <definition value="Element Patient.sdtcEthnicGroupCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -282,7 +264,6 @@
     </element>
     <element id="Patient.guardian">
       <path value="Patient.guardian"/>
-      <definition value="Element Patient.guardian"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -291,7 +272,6 @@
     </element>
     <element id="Patient.birthplace">
       <path value="Patient.birthplace"/>
-      <definition value="Element Patient.birthplace"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -300,7 +280,6 @@
     </element>
     <element id="Patient.languageCommunication">
       <path value="Patient.languageCommunication"/>
-      <definition value="Element Patient.languageCommunication"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/PatientRole.xml
+++ b/input/resources/PatientRole.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PAT"/>
       <fixedCode value="PAT"/>

--- a/input/resources/PatientRole.xml
+++ b/input/resources/PatientRole.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="PatientRole">
       <path value="PatientRole"/>
-      <definition value="Element PatientRole"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="PatientRole.classCode">
       <path value="PatientRole.classCode"/>
-      <definition value="Element PatientRole.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -57,7 +55,6 @@
     </element>
     <element id="PatientRole.id">
       <path value="PatientRole.id"/>
-      <definition value="Element PatientRole.id"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -72,7 +69,6 @@
         <valueString value="identifiedBy"/>
       </extension>
       <path value="PatientRole.sdtcIdentifiedBy"/>
-      <definition value="Element PatientRole.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -81,7 +77,6 @@
     </element>
     <element id="PatientRole.addr">
       <path value="PatientRole.addr"/>
-      <definition value="Element PatientRole.addr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -90,7 +85,6 @@
     </element>
     <element id="PatientRole.telecom">
       <path value="PatientRole.telecom"/>
-      <definition value="Element PatientRole.telecom"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -99,7 +93,6 @@
     </element>
     <element id="PatientRole.patient">
       <path value="PatientRole.patient"/>
-      <definition value="Element PatientRole.patient"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -108,7 +101,6 @@
     </element>
     <element id="PatientRole.providerOrganization">
       <path value="PatientRole.providerOrganization"/>
-      <definition value="Element PatientRole.providerOrganization"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Performer1.xml
+++ b/input/resources/Performer1.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <!-- SG 20230709 Removed the fixed code here - spurious -->
       <!-- <fixedCode value="DOC"/> -->

--- a/input/resources/Performer1.xml
+++ b/input/resources/Performer1.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="Performer1">
       <path value="Performer1"/>
-      <definition value="Element Performer1"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="Performer1.typeCode">
       <path value="Performer1.typeCode"/>
-      <definition value="Element Performer1.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -91,7 +89,6 @@
     </element>
     <element id="Performer1.functionCode">
       <path value="Performer1.functionCode"/>
-      <definition value="Element Performer1.functionCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -100,7 +97,6 @@
     </element>
     <element id="Performer1.time">
       <path value="Performer1.time"/>
-      <definition value="Element Performer1.time"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -109,7 +105,6 @@
     </element>
     <element id="Performer1.assignedEntity">
       <path value="Performer1.assignedEntity"/>
-      <definition value="Element Performer1.assignedEntity"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Performer2.xml
+++ b/input/resources/Performer2.xml
@@ -52,7 +52,6 @@
       <max value="1"/>
       <type>
         <code value="code"/>
-        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-prim"/>
       </type>
       <fixedCode value="PRF"/>
       <binding>

--- a/input/resources/Performer2.xml
+++ b/input/resources/Performer2.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="Performer2">
       <path value="Performer2"/>
-      <definition value="Element Performer2"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="Performer2.typeCode">
       <path value="Performer2.typeCode"/>
-      <definition value="Element Performer2.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -96,7 +94,6 @@
         <valueUri value="functionCode"/>
       </extension>
       <path value="Performer2.sdtcFunctionCode"/>
-      <definition value="Element Performer2.sdtcFunctionCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -105,7 +102,6 @@
     </element>
     <element id="Performer2.time">
       <path value="Performer2.time"/>
-      <definition value="Element Performer2.time"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -114,7 +110,6 @@
     </element>
     <element id="Performer2.modeCode">
       <path value="Performer2.modeCode"/>
-      <definition value="Element Performer2.modeCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -123,7 +118,6 @@
     </element>
     <element id="Performer2.assignedEntity">
       <path value="Performer2.assignedEntity"/>
-      <definition value="Element Performer2.assignedEntity"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Performer2.xml
+++ b/input/resources/Performer2.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="PRF"/>
       <binding>

--- a/input/resources/Person.xml
+++ b/input/resources/Person.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PSN"/>
       <fixedCode value="PSN"/>
@@ -55,6 +56,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INSTANCE"/>
       <fixedCode value="INSTANCE"/>

--- a/input/resources/Person.xml
+++ b/input/resources/Person.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Person">
       <path value="Person"/>
-      <definition value="Element Person"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Person.classCode">
       <path value="Person.classCode"/>
-      <definition value="Element Person.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -50,7 +48,6 @@
     </element>
     <element id="Person.determinerCode">
       <path value="Person.determinerCode"/>
-      <definition value="Element Person.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -77,7 +74,6 @@
     </element>
     <element id="Person.name">
       <path value="Person.name"/>
-      <definition value="Element Person.name"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -92,7 +88,6 @@
         <valueString value="asPatientRelationship"/>
       </extension>
       <path value="Person.sdtcAsPatientRelationship"/>
-      <definition value="Element Person.sdtcAsPatientRelationship"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/Place.xml
+++ b/input/resources/Place.xml
@@ -39,6 +39,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PLC"/>
       <fixedCode value="PLC"/>
@@ -56,6 +57,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INSTANCE"/>
       <fixedCode value="INSTANCE"/>

--- a/input/resources/Place.xml
+++ b/input/resources/Place.xml
@@ -27,13 +27,11 @@
   <differential>
     <element id="Place">
       <path value="Place"/>
-      <definition value="Element Place"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Place.classCode">
       <path value="Place.classCode"/>
-      <definition value="Element Place.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -51,7 +49,6 @@
     </element>
     <element id="Place.determinerCode">
       <path value="Place.determinerCode"/>
-      <definition value="Element Place.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -78,7 +75,6 @@
     </element>
     <element id="Place.name">
       <path value="Place.name"/>
-      <definition value="Element Place.name"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -87,7 +83,6 @@
     </element>
     <element id="Place.addr">
       <path value="Place.addr"/>
-      <definition value="Element Place.addr"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/PlayingEntity.xml
+++ b/input/resources/PlayingEntity.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ENT"/>
       
@@ -47,6 +48,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INSTANCE"/>
       <fixedCode value="INSTANCE"/>

--- a/input/resources/PlayingEntity.xml
+++ b/input/resources/PlayingEntity.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="PlayingEntity">
       <path value="PlayingEntity"/>
-      <definition value="Element PlayingEntity"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="PlayingEntity.classCode">
       <path value="PlayingEntity.classCode"/>
-      <definition value="Element PlayingEntity.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -42,7 +40,6 @@
     </element>
     <element id="PlayingEntity.determinerCode">
       <path value="PlayingEntity.determinerCode"/>
-      <definition value="Element PlayingEntity.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -69,7 +66,6 @@
     </element>
     <element id="PlayingEntity.code">
       <path value="PlayingEntity.code"/>
-      <definition value="Element PlayingEntity.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -82,7 +78,6 @@
     </element>
     <element id="PlayingEntity.quantity">
       <path value="PlayingEntity.quantity"/>
-      <definition value="Element PlayingEntity.quantity"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -91,7 +86,6 @@
     </element>
     <element id="PlayingEntity.name">
       <path value="PlayingEntity.name"/>
-      <definition value="Element PlayingEntity.name"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -106,7 +100,6 @@
         <valueUri value="birthTime"/>
       </extension>
       <path value="PlayingEntity.sdtcBirthTime"/>
-      <definition value="Element PlayingEntity.sdtcBirthTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -115,7 +108,6 @@
     </element>
     <element id="PlayingEntity.desc">
       <path value="PlayingEntity.desc"/>
-      <definition value="Element PlayingEntity.desc"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/Precondition.xml
+++ b/input/resources/Precondition.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>

--- a/input/resources/Precondition.xml
+++ b/input/resources/Precondition.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="Precondition">
       <path value="Precondition"/>
-      <definition value="Element Precondition"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="Precondition.typeCode">
       <path value="Precondition.typeCode"/>
-      <definition value="Element Precondition.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -89,7 +87,6 @@
     </element>
     <element id="Precondition.criterion">
       <path value="Precondition.criterion"/>
-      <definition value="Element Precondition.criterion"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Procedure.xml
+++ b/input/resources/Procedure.xml
@@ -113,6 +113,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Procedure.text">
@@ -404,6 +405,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Procedure.entryRelationship.contextConductionInd">
@@ -414,6 +416,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
       
@@ -435,6 +438,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Procedure.entryRelationship.seperatableInd">

--- a/input/resources/Procedure.xml
+++ b/input/resources/Procedure.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Procedure">
       <path value="Procedure"/>
-      <definition value="Element Procedure"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Procedure.classCode">
       <path value="Procedure.classCode"/>
-      <definition value="Element Procedure.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -49,7 +47,6 @@
     </element>
     <element id="Procedure.moodCode">
       <path value="Procedure.moodCode"/>
-      <definition value="Element Procedure.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -60,7 +57,6 @@
     </element>
     <element id="Procedure.realmCode">
       <path value="Procedure.realmCode"/>
-      <definition value="Element Procedure.realmCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -69,7 +65,6 @@
     </element>
     <element id="Procedure.typeId">
       <path value="Procedure.typeId"/>
-      <definition value="Element Procedure.typeId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -78,7 +73,6 @@
     </element>
     <element id="Procedure.templateId">
       <path value="Procedure.templateId"/>
-      <definition value="Element Procedure.templateId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -88,7 +82,6 @@
     </element>
     <element id="Procedure.id">
       <path value="Procedure.id"/>
-      <definition value="Element Procedure.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -97,7 +90,6 @@
     </element>
     <element id="Procedure.code">
       <path value="Procedure.code"/>
-      <definition value="Element Procedure.code"/>
       <definition value="Drawn from concept domain ActCode"/>
       <min value="0"/>
       <max value="1"/>
@@ -107,7 +99,6 @@
     </element>
     <element id="Procedure.negationInd">
       <path value="Procedure.negationInd"/>
-      <definition value="Element Procedure.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -118,7 +109,6 @@
     </element>
     <element id="Procedure.text">
       <path value="Procedure.text"/>
-      <definition value="Element Procedure.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -127,7 +117,6 @@
     </element>
     <element id="Procedure.statusCode">
       <path value="Procedure.statusCode"/>
-      <definition value="Element Procedure.statusCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -140,7 +129,6 @@
     </element>
     <element id="Procedure.effectiveTime">
       <path value="Procedure.effectiveTime"/>
-      <definition value="Element Procedure.effectiveTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -149,7 +137,6 @@
     </element>
     <element id="Procedure.priorityCode">
       <path value="Procedure.priorityCode"/>
-      <definition value="Element Procedure.priorityCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -162,7 +149,6 @@
     </element>
     <element id="Procedure.languageCode">
       <path value="Procedure.languageCode"/>
-      <definition value="Element Procedure.languageCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -175,7 +161,6 @@
     </element>
     <element id="Procedure.methodCode">
       <path value="Procedure.methodCode"/>
-      <definition value="Element Procedure.methodCode"/>
       <definition value="Drawn from concept domain ProcedureMethod"/>
       <min value="0"/>
       <max value="*"/>
@@ -185,7 +170,6 @@
     </element>
     <element id="Procedure.approachSiteCode">
       <path value="Procedure.approachSiteCode"/>
-      <definition value="Element Procedure.approachSiteCode"/>
       <definition value="Drawn from concept domain ActSite"/>
       <min value="0"/>
       <max value="*"/>
@@ -195,7 +179,6 @@
     </element>
     <element id="Procedure.targetSiteCode">
       <path value="Procedure.targetSiteCode"/>
-      <definition value="Element Procedure.targetSiteCode"/>
       <definition value="Drawn from concept domain ActSite"/>
       <min value="0"/>
       <max value="*"/>
@@ -205,7 +188,6 @@
     </element>
     <element id="Procedure.subject">
       <path value="Procedure.subject"/>
-      <definition value="Element Procedure.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -214,7 +196,6 @@
     </element>
     <element id="Procedure.subject.typeCode">
       <path value="Procedure.subject.typeCode"/>
-      <definition value="Element Procedure.subject.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -232,7 +213,6 @@
     </element>
     <element id="Procedure.subject.contextControlCode">
       <path value="Procedure.subject.contextControlCode"/>
-      <definition value="Element Procedure.subject.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -250,7 +230,6 @@
     </element>
     <element id="Procedure.subject.awarenessCode">
       <path value="Procedure.subject.awarenessCode"/>
-      <definition value="Element Procedure.subject.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -263,7 +242,6 @@
     </element>
     <element id="Procedure.subject.relatedSubject">
       <path value="Procedure.subject.relatedSubject"/>
-      <definition value="Element Procedure.subject.relatedSubject"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -272,7 +250,6 @@
     </element>
     <element id="Procedure.specimen">
       <path value="Procedure.specimen"/>
-      <definition value="Element Procedure.specimen"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -281,7 +258,6 @@
     </element>
     <element id="Procedure.performer">
       <path value="Procedure.performer"/>
-      <definition value="Element Procedure.performer"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -290,7 +266,6 @@
     </element>
     <element id="Procedure.author">
       <path value="Procedure.author"/>
-      <definition value="Element Procedure.author"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -299,7 +274,6 @@
     </element>
     <element id="Procedure.informant">
       <path value="Procedure.informant"/>
-      <definition value="Element Procedure.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -308,7 +282,6 @@
     </element>
     <element id="Procedure.informant.typeCode">
       <path value="Procedure.informant.typeCode"/>
-      <definition value="Element Procedure.informant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -326,7 +299,6 @@
     </element>
     <element id="Procedure.informant.contextControlCode">
       <path value="Procedure.informant.contextControlCode"/>
-      <definition value="Element Procedure.informant.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -344,7 +316,6 @@
     </element>
     <element id="Procedure.informant.assignedEntity">
       <path value="Procedure.informant.assignedEntity"/>
-      <definition value="Element Procedure.informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -353,7 +324,6 @@
     </element>
     <element id="Procedure.informant.relatedEntity">
       <path value="Procedure.informant.relatedEntity"/>
-      <definition value="Element Procedure.informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -362,7 +332,6 @@
     </element>
     <element id="Procedure.participant">
       <path value="Procedure.participant"/>
-      <definition value="Element Procedure.participant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -371,7 +340,6 @@
     </element>
     <element id="Procedure.entryRelationship">
       <path value="Procedure.entryRelationship"/>
-      <definition value="Element Procedure.entryRelationship"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -387,7 +355,6 @@
     </element>
     <element id="Procedure.entryRelationship.typeCode">
       <path value="Procedure.entryRelationship.typeCode"/>
-      <definition value="Element Procedure.entryRelationship.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -399,7 +366,6 @@
     </element>
     <element id="Procedure.entryRelationship.inversionInd">
       <path value="Procedure.entryRelationship.inversionInd"/>
-      <definition value="Element Procedure.entryRelationship.inversionInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -410,7 +376,6 @@
     </element>
     <element id="Procedure.entryRelationship.contextConductionInd">
       <path value="Procedure.entryRelationship.contextConductionInd"/>
-      <definition value="Element Procedure.entryRelationship.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -423,7 +388,6 @@
     </element>
     <element id="Procedure.entryRelationship.sequenceNumber">
       <path value="Procedure.entryRelationship.sequenceNumber"/>
-      <definition value="Element Procedure.entryRelationship.sequenceNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -432,7 +396,6 @@
     </element>
     <element id="Procedure.entryRelationship.negationInd">
       <path value="Procedure.entryRelationship.negationInd"/>
-      <definition value="Element Procedure.entryRelationship.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -443,7 +406,6 @@
     </element>
     <element id="Procedure.entryRelationship.seperatableInd">
       <path value="Procedure.entryRelationship.seperatableInd"/>
-      <definition value="Element Procedure.entryRelationship.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -452,7 +414,6 @@
     </element>
     <element id="Procedure.entryRelationship.observation">
       <path value="Procedure.entryRelationship.observation"/>
-      <definition value="Element Procedure.entryRelationship.observation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -461,7 +422,6 @@
     </element>
     <element id="Procedure.entryRelationship.regionOfInterest">
       <path value="Procedure.entryRelationship.regionOfInterest"/>
-      <definition value="Element Procedure.entryRelationship.regionOfInterest"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -470,7 +430,6 @@
     </element>
     <element id="Procedure.entryRelationship.observationMedia">
       <path value="Procedure.entryRelationship.observationMedia"/>
-      <definition value="Element Procedure.entryRelationship.observationMedia"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -479,7 +438,6 @@
     </element>
     <element id="Procedure.entryRelationship.substanceAdministration">
       <path value="Procedure.entryRelationship.substanceAdministration"/>
-      <definition value="Element Procedure.entryRelationship.substanceAdministration"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -488,7 +446,6 @@
     </element>
     <element id="Procedure.entryRelationship.supply">
       <path value="Procedure.entryRelationship.supply"/>
-      <definition value="Element Procedure.entryRelationship.supply"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -497,7 +454,6 @@
     </element>
     <element id="Procedure.entryRelationship.procedure">
       <path value="Procedure.entryRelationship.procedure"/>
-      <definition value="Element Procedure.entryRelationship.procedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -506,7 +462,6 @@
     </element>
     <element id="Procedure.entryRelationship.encounter">
       <path value="Procedure.entryRelationship.encounter"/>
-      <definition value="Element Procedure.entryRelationship.encounter"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -515,7 +470,6 @@
     </element>
     <element id="Procedure.entryRelationship.organizer">
       <path value="Procedure.entryRelationship.organizer"/>
-      <definition value="Element Procedure.entryRelationship.organizer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -524,7 +478,6 @@
     </element>
     <element id="Procedure.entryRelationship.act">
       <path value="Procedure.entryRelationship.act"/>
-      <definition value="Element Procedure.entryRelationship.act"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -533,7 +486,6 @@
     </element>
     <element id="Procedure.reference">
       <path value="Procedure.reference"/>
-      <definition value="Element Procedure.reference"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -542,7 +494,6 @@
     </element>
     <element id="Procedure.reference.typeCode">
       <path value="Procedure.reference.typeCode"/>
-      <definition value="Element Procedure.reference.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -554,7 +505,6 @@
     </element>
     <element id="Procedure.reference.seperatableInd">
       <path value="Procedure.reference.seperatableInd"/>
-      <definition value="Element Procedure.reference.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -563,7 +513,6 @@
     </element>
     <element id="Procedure.reference.externalAct">
       <path value="Procedure.reference.externalAct"/>
-      <definition value="Element Procedure.reference.externalAct"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -572,7 +521,6 @@
     </element>
     <element id="Procedure.reference.externalObservation">
       <path value="Procedure.reference.externalObservation"/>
-      <definition value="Element Procedure.reference.externalObservation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -581,7 +529,6 @@
     </element>
     <element id="Procedure.reference.externalProcedure">
       <path value="Procedure.reference.externalProcedure"/>
-      <definition value="Element Procedure.reference.externalProcedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -590,7 +537,6 @@
     </element>
     <element id="Procedure.reference.externalDocument">
       <path value="Procedure.reference.externalDocument"/>
-      <definition value="Element Procedure.reference.externalDocument"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -599,7 +545,6 @@
     </element>
     <element id="Procedure.precondition">
       <path value="Procedure.precondition"/>
-      <definition value="Element Procedure.precondition"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/Procedure.xml
+++ b/input/resources/Procedure.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PROC"/>
       <fixedCode value="PROC"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="Procedure.realmCode">
@@ -217,6 +219,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBJ"/>
       <fixedCode value="SBJ"/>
@@ -234,6 +237,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -309,6 +313,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INF"/>
       <fixedCode value="INF"/>
@@ -326,6 +331,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -386,6 +392,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>
@@ -537,6 +544,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>

--- a/input/resources/REAL.xml
+++ b/input/resources/REAL.xml
@@ -31,7 +31,6 @@
     </element>
     <element id="REAL.value">
       <path value="REAL.value"/>
-      <definition value="Element REAL.value"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>

--- a/input/resources/REAL.xml
+++ b/input/resources/REAL.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="decimal"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/real-simple"/>
       </type>
     </element>
   </differential>

--- a/input/resources/RTO-PQ-PQ.xml
+++ b/input/resources/RTO-PQ-PQ.xml
@@ -19,7 +19,6 @@
   <differential>
     <element id="RTO_PQ_PQ">
       <path value="RTO_PQ_PQ"/>
-      <definition value="Element RTO_PQ_PQ"/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/input/resources/RecordTarget.xml
+++ b/input/resources/RecordTarget.xml
@@ -29,7 +29,6 @@
   <differential>
     <element id="RecordTarget">
       <path value="RecordTarget"/>
-      <definition value="Element RecordTarget"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -51,7 +50,6 @@
     </element>
     <element id="RecordTarget.typeCode">
       <path value="RecordTarget.typeCode"/>
-      <definition value="Element RecordTarget.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -68,7 +66,6 @@
     </element>
     <element id="RecordTarget.contextControlCode">
       <path value="RecordTarget.contextControlCode"/>
-      <definition value="Element RecordTarget.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -112,7 +109,6 @@
     </element>
     <element id="RecordTarget.patientRole">
       <path value="RecordTarget.patientRole"/>
-      <definition value="Element RecordTarget.patientRole"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/RecordTarget.xml
+++ b/input/resources/RecordTarget.xml
@@ -42,6 +42,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -56,6 +57,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="RCT"/>
       
@@ -72,6 +74,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="OP"/>
       

--- a/input/resources/RegionOfInterest.xml
+++ b/input/resources/RegionOfInterest.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="RegionOfInterest">
       <path value="RegionOfInterest"/>
-      <definition value="Element RegionOfInterest"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="RegionOfInterest.ID">
       <path value="RegionOfInterest.ID"/>
-      <definition value="Element RegionOfInterest.ID"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -43,7 +41,6 @@
     </element>
     <element id="RegionOfInterest.classCode">
       <path value="RegionOfInterest.classCode"/>
-      <definition value="Element RegionOfInterest.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -60,7 +57,6 @@
     </element>
     <element id="RegionOfInterest.moodCode">
       <path value="RegionOfInterest.moodCode"/>
-      <definition value="Element RegionOfInterest.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -77,7 +73,6 @@
     </element>
     <element id="RegionOfInterest.realmCode">
       <path value="RegionOfInterest.realmCode"/>
-      <definition value="Element RegionOfInterest.realmCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -86,7 +81,6 @@
     </element>
     <element id="RegionOfInterest.typeId">
       <path value="RegionOfInterest.typeId"/>
-      <definition value="Element RegionOfInterest.typeId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -95,7 +89,6 @@
     </element>
     <element id="RegionOfInterest.templateId">
       <path value="RegionOfInterest.templateId"/>
-      <definition value="Element RegionOfInterest.templateId"/>
       <definition value="When valued in an instance, this attribute signals the imposition of a set of template-defined constraints. The value of this attribute provides a unique identifier for the templates in question"/>
       <min value="0"/>
       <max value="*"/>
@@ -105,7 +98,6 @@
     </element>
     <element id="RegionOfInterest.id">
       <path value="RegionOfInterest.id"/>
-      <definition value="Element RegionOfInterest.id"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -114,7 +106,6 @@
     </element>
     <element id="RegionOfInterest.code">
       <path value="RegionOfInterest.code"/>
-      <definition value="Element RegionOfInterest.code"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -124,7 +115,6 @@
     </element>
     <element id="RegionOfInterest.value">
       <path value="RegionOfInterest.value"/>
-      <definition value="Element RegionOfInterest.value"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -134,7 +124,6 @@
     </element>
     <element id="RegionOfInterest.subject">
       <path value="RegionOfInterest.subject"/>
-      <definition value="Element RegionOfInterest.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -143,7 +132,6 @@
     </element>
     <element id="RegionOfInterest.subject.typeCode">
       <path value="RegionOfInterest.subject.typeCode"/>
-      <definition value="Element RegionOfInterest.subject.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -161,7 +149,6 @@
     </element>
     <element id="RegionOfInterest.subject.contextControlCode">
       <path value="RegionOfInterest.subject.contextControlCode"/>
-      <definition value="Element RegionOfInterest.subject.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -179,7 +166,6 @@
     </element>
     <element id="RegionOfInterest.subject.awarenessCode">
       <path value="RegionOfInterest.subject.awarenessCode"/>
-      <definition value="Element RegionOfInterest.subject.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -192,7 +178,6 @@
     </element>
     <element id="RegionOfInterest.subject.relatedSubject">
       <path value="RegionOfInterest.subject.relatedSubject"/>
-      <definition value="Element RegionOfInterest.subject.relatedSubject"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -201,7 +186,6 @@
     </element>
     <element id="RegionOfInterest.specimen">
       <path value="RegionOfInterest.specimen"/>
-      <definition value="Element RegionOfInterest.specimen"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -210,7 +194,6 @@
     </element>
     <element id="RegionOfInterest.performer">
       <path value="RegionOfInterest.performer"/>
-      <definition value="Element RegionOfInterest.performer"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -219,7 +202,6 @@
     </element>
     <element id="RegionOfInterest.author">
       <path value="RegionOfInterest.author"/>
-      <definition value="Element RegionOfInterest.author"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -228,7 +210,6 @@
     </element>
     <element id="RegionOfInterest.informant">
       <path value="RegionOfInterest.informant"/>
-      <definition value="Element RegionOfInterest.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -237,7 +218,6 @@
     </element>
     <element id="RegionOfInterest.informant.typeCode">
       <path value="RegionOfInterest.informant.typeCode"/>
-      <definition value="Element RegionOfInterest.informant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -255,7 +235,6 @@
     </element>
     <element id="RegionOfInterest.informant.contextControlCode">
       <path value="RegionOfInterest.informant.contextControlCode"/>
-      <definition value="Element RegionOfInterest.informant.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -273,7 +252,6 @@
     </element>
     <element id="RegionOfInterest.informant.assignedEntity">
       <path value="RegionOfInterest.informant.assignedEntity"/>
-      <definition value="Element RegionOfInterest.informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -282,7 +260,6 @@
     </element>
     <element id="RegionOfInterest.informant.relatedEntity">
       <path value="RegionOfInterest.informant.relatedEntity"/>
-      <definition value="Element RegionOfInterest.informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -291,7 +268,6 @@
     </element>
     <element id="RegionOfInterest.participant">
       <path value="RegionOfInterest.participant"/>
-      <definition value="Element RegionOfInterest.participant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -300,7 +276,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship">
       <path value="RegionOfInterest.entryRelationship"/>
-      <definition value="Element RegionOfInterest.entryRelationship"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -316,7 +291,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.typeCode">
       <path value="RegionOfInterest.entryRelationship.typeCode"/>
-      <definition value="Element RegionOfInterest.entryRelationship.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -328,7 +302,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.inversionInd">
       <path value="RegionOfInterest.entryRelationship.inversionInd"/>
-      <definition value="Element RegionOfInterest.entryRelationship.inversionInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -339,7 +312,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.contextConductionInd">
       <path value="RegionOfInterest.entryRelationship.contextConductionInd"/>
-      <definition value="Element RegionOfInterest.entryRelationship.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -352,7 +324,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.sequenceNumber">
       <path value="RegionOfInterest.entryRelationship.sequenceNumber"/>
-      <definition value="Element RegionOfInterest.entryRelationship.sequenceNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -361,7 +332,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.negationInd">
       <path value="RegionOfInterest.entryRelationship.negationInd"/>
-      <definition value="Element RegionOfInterest.entryRelationship.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -372,7 +342,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.seperatableInd">
       <path value="RegionOfInterest.entryRelationship.seperatableInd"/>
-      <definition value="Element RegionOfInterest.entryRelationship.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -381,7 +350,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.observation">
       <path value="RegionOfInterest.entryRelationship.observation"/>
-      <definition value="Element RegionOfInterest.entryRelationship.observation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -390,7 +358,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.regionOfInterest">
       <path value="RegionOfInterest.entryRelationship.regionOfInterest"/>
-      <definition value="Element RegionOfInterest.entryRelationship.regionOfInterest"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -399,7 +366,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.observationMedia">
       <path value="RegionOfInterest.entryRelationship.observationMedia"/>
-      <definition value="Element RegionOfInterest.entryRelationship.observationMedia"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -408,7 +374,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.substanceAdministration">
       <path value="RegionOfInterest.entryRelationship.substanceAdministration"/>
-      <definition value="Element RegionOfInterest.entryRelationship.substanceAdministration"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -417,7 +382,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.supply">
       <path value="RegionOfInterest.entryRelationship.supply"/>
-      <definition value="Element RegionOfInterest.entryRelationship.supply"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -426,7 +390,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.procedure">
       <path value="RegionOfInterest.entryRelationship.procedure"/>
-      <definition value="Element RegionOfInterest.entryRelationship.procedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -435,7 +398,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.encounter">
       <path value="RegionOfInterest.entryRelationship.encounter"/>
-      <definition value="Element RegionOfInterest.entryRelationship.encounter"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -444,7 +406,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.organizer">
       <path value="RegionOfInterest.entryRelationship.organizer"/>
-      <definition value="Element RegionOfInterest.entryRelationship.organizer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -453,7 +414,6 @@
     </element>
     <element id="RegionOfInterest.entryRelationship.act">
       <path value="RegionOfInterest.entryRelationship.act"/>
-      <definition value="Element RegionOfInterest.entryRelationship.act"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -462,7 +422,6 @@
     </element>
     <element id="RegionOfInterest.reference">
       <path value="RegionOfInterest.reference"/>
-      <definition value="Element RegionOfInterest.reference"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -471,7 +430,6 @@
     </element>
     <element id="RegionOfInterest.reference.typeCode">
       <path value="RegionOfInterest.reference.typeCode"/>
-      <definition value="Element RegionOfInterest.reference.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -483,7 +441,6 @@
     </element>
     <element id="RegionOfInterest.reference.seperatableInd">
       <path value="RegionOfInterest.reference.seperatableInd"/>
-      <definition value="Element RegionOfInterest.reference.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -492,7 +449,6 @@
     </element>
     <element id="RegionOfInterest.reference.externalAct">
       <path value="RegionOfInterest.reference.externalAct"/>
-      <definition value="Element RegionOfInterest.reference.externalAct"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -501,7 +457,6 @@
     </element>
     <element id="RegionOfInterest.reference.externalObservation">
       <path value="RegionOfInterest.reference.externalObservation"/>
-      <definition value="Element RegionOfInterest.reference.externalObservation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -510,7 +465,6 @@
     </element>
     <element id="RegionOfInterest.reference.externalProcedure">
       <path value="RegionOfInterest.reference.externalProcedure"/>
-      <definition value="Element RegionOfInterest.reference.externalProcedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -519,7 +473,6 @@
     </element>
     <element id="RegionOfInterest.reference.externalDocument">
       <path value="RegionOfInterest.reference.externalDocument"/>
-      <definition value="Element RegionOfInterest.reference.externalDocument"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -528,7 +481,6 @@
     </element>
     <element id="RegionOfInterest.precondition">
       <path value="RegionOfInterest.precondition"/>
-      <definition value="Element RegionOfInterest.precondition"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/RegionOfInterest.xml
+++ b/input/resources/RegionOfInterest.xml
@@ -48,6 +48,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ROIOVL"/>
       <fixedCode value="ROIOVL"/>
@@ -64,6 +65,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>
@@ -146,6 +148,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBJ"/>
       <fixedCode value="SBJ"/>
@@ -163,6 +166,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -238,6 +242,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INF"/>
       <fixedCode value="INF"/>
@@ -255,6 +260,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -315,6 +321,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>
@@ -466,6 +473,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>

--- a/input/resources/RegionOfInterest.xml
+++ b/input/resources/RegionOfInterest.xml
@@ -333,6 +333,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="RegionOfInterest.entryRelationship.contextConductionInd">
@@ -343,6 +344,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
       
@@ -364,6 +366,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="RegionOfInterest.entryRelationship.seperatableInd">

--- a/input/resources/RegionOfInterest.xml
+++ b/input/resources/RegionOfInterest.xml
@@ -37,7 +37,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="id"/>
       </type>
     </element>
     <element id="RegionOfInterest.classCode">

--- a/input/resources/RegionOfInterest.xml
+++ b/input/resources/RegionOfInterest.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="id"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/xs-ID"/>
       </type>
     </element>
     <element id="RegionOfInterest.classCode">

--- a/input/resources/RelatedDocument.xml
+++ b/input/resources/RelatedDocument.xml
@@ -25,7 +25,6 @@
   <differential>
     <element id="RelatedDocument">
       <path value="RelatedDocument"/>
-      <definition value="Element RelatedDocument"/>
       <min value="1"/>
       <max value="1"/>
     </element>
@@ -47,7 +46,6 @@
     </element>
     <element id="RelatedDocument.typeCode">
       <path value="RelatedDocument.typeCode"/>
-      <definition value="Element RelatedDocument.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -90,7 +88,6 @@
     </element>
     <element id="RelatedDocument.parentDocument">
       <path value="RelatedDocument.parentDocument"/>
-      <definition value="Element RelatedDocument.parentDocument"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/RelatedDocument.xml
+++ b/input/resources/RelatedDocument.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -52,6 +53,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
       <binding>

--- a/input/resources/RelatedEntity.xml
+++ b/input/resources/RelatedEntity.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
       <binding>

--- a/input/resources/RelatedEntity.xml
+++ b/input/resources/RelatedEntity.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="RelatedEntity">
       <path value="RelatedEntity"/>
-      <definition value="Element RelatedEntity"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="RelatedEntity.classCode">
       <path value="RelatedEntity.classCode"/>
-      <definition value="Element RelatedEntity.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -56,7 +54,6 @@
     </element>
     <element id="RelatedEntity.code">
       <path value="RelatedEntity.code"/>
-      <definition value="Element RelatedEntity.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -69,7 +66,6 @@
     </element>
     <element id="RelatedEntity.addr">
       <path value="RelatedEntity.addr"/>
-      <definition value="Element RelatedEntity.addr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -78,7 +74,6 @@
     </element>
     <element id="RelatedEntity.telecom">
       <path value="RelatedEntity.telecom"/>
-      <definition value="Element RelatedEntity.telecom"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -87,7 +82,6 @@
     </element>
     <element id="RelatedEntity.effectiveTime">
       <path value="RelatedEntity.effectiveTime"/>
-      <definition value="Element RelatedEntity.effectiveTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -96,7 +90,6 @@
     </element>
     <element id="RelatedEntity.relatedPerson">
       <path value="RelatedEntity.relatedPerson"/>
-      <definition value="Element RelatedEntity.relatedPerson"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/RelatedSubject.xml
+++ b/input/resources/RelatedSubject.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="RelatedSubject">
       <path value="RelatedSubject"/>
-      <definition value="Element RelatedSubject"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="RelatedSubject.classCode">
       <path value="RelatedSubject.classCode"/>
-      <definition value="Element RelatedSubject.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -53,7 +51,6 @@
     </element>
     <element id="RelatedSubject.code">
       <path value="RelatedSubject.code"/>
-      <definition value="Element RelatedSubject.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -66,7 +63,6 @@
     </element>
     <element id="RelatedSubject.addr">
       <path value="RelatedSubject.addr"/>
-      <definition value="Element RelatedSubject.addr"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -75,7 +71,6 @@
     </element>
     <element id="RelatedSubject.telecom">
       <path value="RelatedSubject.telecom"/>
-      <definition value="Element RelatedSubject.telecom"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -84,7 +79,6 @@
     </element>
     <element id="RelatedSubject.subject">
       <path value="RelatedSubject.subject"/>
-      <definition value="Element RelatedSubject.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/RelatedSubject.xml
+++ b/input/resources/RelatedSubject.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PRS"/>
       

--- a/input/resources/SC.xml
+++ b/input/resources/SC.xml
@@ -43,7 +43,8 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="SC.codeSystem">
@@ -54,7 +55,10 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="id"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/oid"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/uuid"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/ruid"/>
       </type>
     </element>
     <element id="SC.codeSystemName">
@@ -66,6 +70,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
     <element id="SC.codeSystemVersion">
@@ -77,6 +82,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
     <element id="SC.displayName">
@@ -88,6 +94,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
   </differential>

--- a/input/resources/SC.xml
+++ b/input/resources/SC.xml
@@ -53,7 +53,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="id"/>
+        <code value="string"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/oid"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/uuid"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/ruid"/>

--- a/input/resources/SC.xml
+++ b/input/resources/SC.xml
@@ -37,7 +37,6 @@
     </element>
     <element id="SC.code">
       <path value="SC.code"/>
-      <definition value="Element SC.code"/>
       <representation value="xmlAttr"/>
       <label value="Code"/>
       <min value="0"/>
@@ -49,7 +48,6 @@
     </element>
     <element id="SC.codeSystem">
       <path value="SC.codeSystem"/>
-      <definition value="Element SC.codeSystem"/>
       <representation value="xmlAttr"/>
       <label value="Code System"/>
       <min value="0"/>
@@ -63,7 +61,6 @@
     </element>
     <element id="SC.codeSystemName">
       <path value="SC.codeSystemName"/>
-      <definition value="Element SC.codeSystemName"/>
       <representation value="xmlAttr"/>
       <label value="Code System Name"/>
       <min value="0"/>
@@ -75,7 +72,6 @@
     </element>
     <element id="SC.codeSystemVersion">
       <path value="SC.codeSystemVersion"/>
-      <definition value="Element SC.codeSystemVersion"/>
       <representation value="xmlAttr"/>
       <label value="Code System Version"/>
       <min value="0"/>
@@ -87,7 +83,6 @@
     </element>
     <element id="SC.displayName">
       <path value="SC.displayName"/>
-      <definition value="Element SC.displayName"/>
       <representation value="xmlAttr"/>
       <label value="Display Name"/>
       <min value="0"/>

--- a/input/resources/ST.xml
+++ b/input/resources/ST.xml
@@ -86,6 +86,7 @@
       <max value="1"/>
       <type>
         <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
     </element>
     <element id="ED.reference">

--- a/input/resources/ST.xml
+++ b/input/resources/ST.xml
@@ -19,42 +19,30 @@
   <description value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="http://hl7.org/cda/stds/core/StructureDefinition/ED"/>
-  <baseDefinition value="http://hl7.org/cda/stds/core/StructureDefinition/ED"/>
-  <derivation value="constraint"/>
+  <type value="http://hl7.org/cda/stds/core/StructureDefinition/ST"/>
+  <baseDefinition value="http://hl7.org/cda/stds/core/StructureDefinition/ANY"/>
+  <derivation value="specialization"/>
   <differential>
-    <element id="ED">
-      <path value="ED"/>
+    <element id="ST">
+      <path value="ST"/>
       <definition value="The character string data type stands for text data, primarily intended for machine processing (e.g., sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="ED.compression">
-      <path value="ED.compression"/>
+    <element id="ST.representation">
+      <path value="ST.representation"/>
       <representation value="xmlAttr"/>
-      <label value="Compression"/>
-      <definition value="Indicates whether the raw byte data is compressed, and what compression algorithm was used."/>
+      <definition value="Specifies the representation of the binary data that is the content of the binary data value"/>
       <min value="0"/>
-      <max value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
+      </type>
+      <fixedCode value="TXT"/>
     </element>
-    <element id="ED.integrityCheck">
-      <path value="ED.integrityCheck"/>
-      <representation value="xmlAttr"/>
-      <label value="Integrity Check"/>
-      <definition value="The integrity check is a short binary value representing a cryptographically strong checksum that is calculated over the binary data. The purpose of this property, when communicated with a reference is for anyone to validate later whether the reference still resolved to the same data that the reference resolved to when the encapsulated data value with reference was created."/>
-      <min value="0"/>
-      <max value="0"/>
-    </element>
-    <element id="ED.integrityCheckAlgorithm">
-      <path value="ED.integrityCheckAlgorithm"/>
-      <representation value="xmlAttr"/>
-      <label value="Integrity Check Algorithm"/>
-      <definition value="Specifies the algorithm used to compute the integrityCheck value. The cryptographically strong checksum algorithm Secure Hash Algorithm-1 (SHA-1) is currently the industry standard. It has superseded the MD5 algorithm only a couple of years ago, when certain flaws in the security of MD5 were discovered. Currently the SHA-1 hash algorithm is the default choice for the integrity check algorithm. Note that SHA-256 is also entering widespread usage."/>
-      <min value="0"/>
-      <max value="0"/>
-    </element>
-    <element id="ED.mediaType">
-      <path value="ED.mediaType"/>
+    <element id="ST.mediaType">
+      <path value="ST.mediaType"/>
       <representation value="xmlAttr"/>
       <label value="Media Type"/>
       <definition value="Identifies the type of the encapsulated data and identifies a method to interpret or render the data."/>
@@ -66,20 +54,20 @@
       </type>
       <fixedCode value="text/plain"/>
     </element>
-    <element id="ED.representation">
-      <path value="ED.representation"/>
+    <element id="ST.language">
+      <path value="ST.language"/>
       <representation value="xmlAttr"/>
-      <definition value="Specifies the representation of the binary data that is the content of the binary data value"/>
+      <label value="Language"/>
+      <definition value="For character based information the language property specifies the human language of the text."/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="code"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
-      <fixedCode value="TXT"/>
     </element>
-    <element id="ED.data[x]">
-      <path value="ED.data[x]"/>
+    <element id="ST.data[x]">
+      <path value="ST.data[x]"/>
       <representation value="xmlText"/>
       <definition value="The string value"/>
       <min value="0"/>
@@ -88,20 +76,6 @@
         <code value="string"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple" />
       </type>
-    </element>
-    <element id="ED.reference">
-      <path value="ED.reference"/>
-      <label value="Reference"/>
-      <definition value="A telecommunication address (TEL), such as a URL for HTTP or FTP, which will resolve to precisely the same binary data that could as well have been provided as inline data."/>
-      <min value="0"/>
-      <max value="0"/>
-    </element>
-    <element id="ED.thumbnail">
-      <path value="ED.thumbnail"/>
-      <label value="Thumbnail"/>
-      <definition value="An abbreviated rendition of the full data. A thumbnail requires significantly fewer resources than the full data, while still maintaining some distinctive similarity with the full data. A thumbnail is typically used with by-reference encapsulated data. It allows a user to select data more efficiently before actually downloading through the reference."/>
-      <min value="0"/>
-      <max value="0"/>
     </element>
   </differential>
 </StructureDefinition>

--- a/input/resources/ST.xml
+++ b/input/resources/ST.xml
@@ -62,6 +62,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="text/plain"/>
     </element>
@@ -73,6 +74,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <fixedCode value="TXT"/>
     </element>

--- a/input/resources/SXCM-TS.xml
+++ b/input/resources/SXCM-TS.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
   </differential>

--- a/input/resources/SXCM-TS.xml
+++ b/input/resources/SXCM-TS.xml
@@ -19,7 +19,6 @@
   <differential>
     <element id="SXCM_TS">
       <path value="SXCM_TS"/>
-      <definition value="Element SXCM_TS"/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/input/resources/SXPR-TS.xml
+++ b/input/resources/SXPR-TS.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="SXPR_TS">
       <path value="SXPR_TS"/>
-      <definition value="Element SXPR_TS"/>
       <min value="1"/>
       <max value="*"/>
     </element>
     <element id="SXPR_TS.comp">
       <path value="SXPR_TS.comp"/>
-      <definition value="Element SXPR_TS.comp"/>
       <representation value="typeAttr"/>
       <min value="1"/>
       <max value="*"/>

--- a/input/resources/Section.xml
+++ b/input/resources/Section.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="id"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/xs-ID"/>
       </type>
     </element>
     <element id="Section.nullFlavor">

--- a/input/resources/Section.xml
+++ b/input/resources/Section.xml
@@ -341,6 +341,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
     </element>
@@ -457,6 +458,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
       

--- a/input/resources/Section.xml
+++ b/input/resources/Section.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="Section">
       <path value="Section"/>
-      <definition value="Element Section"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Section.ID">
       <path value="Section.ID"/>
-      <definition value="Element Section.ID"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -43,7 +41,6 @@
     </element>
     <element id="Section.nullFlavor">
       <path value="Section.nullFlavor"/>
-      <definition value="Element Section.nullFlavor"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -63,7 +60,6 @@
     </element>
     <element id="Section.classCode">
       <path value="Section.classCode"/>
-      <definition value="Element Section.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -80,7 +76,6 @@
     </element>
     <element id="Section.moodCode">
       <path value="Section.moodCode"/>
-      <definition value="Element Section.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -106,7 +101,6 @@
     </element>
     <element id="Section.id">
       <path value="Section.id"/>
-      <definition value="Element Section.id"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -115,7 +109,6 @@
     </element>
     <element id="Section.code">
       <path value="Section.code"/>
-      <definition value="Element Section.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -128,7 +121,6 @@
     </element>
     <element id="Section.title">
       <path value="Section.title"/>
-      <definition value="Element Section.title"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -137,7 +129,6 @@
     </element>
     <element id="Section.text">
       <path value="Section.text"/>
-      <definition value="Element Section.text"/>
       <representation value="cdaText"/>
       <min value="0"/>
       <max value="1"/>
@@ -148,7 +139,6 @@
     </element>
     <element id="Section.confidentialityCode">
       <path value="Section.confidentialityCode"/>
-      <definition value="Element Section.confidentialityCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -157,7 +147,6 @@
     </element>
     <element id="Section.languageCode">
       <path value="Section.languageCode"/>
-      <definition value="Element Section.languageCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -170,7 +159,6 @@
     </element>
     <element id="Section.subject">
       <path value="Section.subject"/>
-      <definition value="Element Section.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -179,7 +167,6 @@
     </element>
     <element id="Section.subject.typeCode">
       <path value="Section.subject.typeCode"/>
-      <definition value="Element Section.subject.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -197,7 +184,6 @@
     </element>
     <element id="Section.subject.contextControlCode">
       <path value="Section.subject.contextControlCode"/>
-      <definition value="Element Section.subject.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -215,7 +201,6 @@
     </element>
     <element id="Section.subject.awarenessCode">
       <path value="Section.subject.awarenessCode"/>
-      <definition value="Element Section.subject.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -228,7 +213,6 @@
     </element>
     <element id="Section.subject.relatedSubject">
       <path value="Section.subject.relatedSubject"/>
-      <definition value="Element Section.subject.relatedSubject"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -237,7 +221,6 @@
     </element>
     <element id="Section.author">
       <path value="Section.author"/>
-      <definition value="Element Section.author"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -246,7 +229,6 @@
     </element>
     <element id="Section.informant">
       <path value="Section.informant"/>
-      <definition value="Element Section.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -255,7 +237,6 @@
     </element>
     <element id="Section.informant.typeCode">
       <path value="Section.informant.typeCode"/>
-      <definition value="Element Section.informant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -273,7 +254,6 @@
     </element>
     <element id="Section.informant.contextControlCode">
       <path value="Section.informant.contextControlCode"/>
-      <definition value="Element Section.informant.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -291,7 +271,6 @@
     </element>
     <element id="Section.informant.assignedEntity">
       <path value="Section.informant.assignedEntity"/>
-      <definition value="Element Section.informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -300,7 +279,6 @@
     </element>
     <element id="Section.informant.relatedEntity">
       <path value="Section.informant.relatedEntity"/>
-      <definition value="Element Section.informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -309,7 +287,6 @@
     </element>
     <element id="Section.entry">
       <path value="Section.entry"/>
-      <definition value="Element Section.entry"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -324,7 +301,6 @@
     </element>
     <element id="Section.entry.typeCode">
       <path value="Section.entry.typeCode"/>
-      <definition value="Element Section.entry.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -336,7 +312,6 @@
     </element>
     <element id="Section.entry.contextConductionInd">
       <path value="Section.entry.contextConductionInd"/>
-      <definition value="Element Section.entry.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -348,7 +323,6 @@
     </element>
     <element id="Section.entry.observation">
       <path value="Section.entry.observation"/>
-      <definition value="Element Section.entry.observation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -357,7 +331,6 @@
     </element>
     <element id="Section.entry.regionOfInterest">
       <path value="Section.entry.regionOfInterest"/>
-      <definition value="Element Section.entry.regionOfInterest"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -366,7 +339,6 @@
     </element>
     <element id="Section.entry.observationMedia">
       <path value="Section.entry.observationMedia"/>
-      <definition value="Element Section.entry.observationMedia"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -375,7 +347,6 @@
     </element>
     <element id="Section.entry.substanceAdministration">
       <path value="Section.entry.substanceAdministration"/>
-      <definition value="Element Section.entry.substanceAdministration"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -384,7 +355,6 @@
     </element>
     <element id="Section.entry.supply">
       <path value="Section.entry.supply"/>
-      <definition value="Element Section.entry.supply"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -393,7 +363,6 @@
     </element>
     <element id="Section.entry.procedure">
       <path value="Section.entry.procedure"/>
-      <definition value="Element Section.entry.procedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -402,7 +371,6 @@
     </element>
     <element id="Section.entry.encounter">
       <path value="Section.entry.encounter"/>
-      <definition value="Element Section.entry.encounter"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -411,7 +379,6 @@
     </element>
     <element id="Section.entry.organizer">
       <path value="Section.entry.organizer"/>
-      <definition value="Element Section.entry.organizer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -420,7 +387,6 @@
     </element>
     <element id="Section.entry.act">
       <path value="Section.entry.act"/>
-      <definition value="Element Section.entry.act"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -429,7 +395,6 @@
     </element>
     <element id="Section.component">
       <path value="Section.component"/>
-      <definition value="Element Section.component"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -438,7 +403,6 @@
     </element>
     <element id="Section.component.typeCode">
       <path value="Section.component.typeCode"/>
-      <definition value="Element Section.component.typeCode"/>
       <definition value="Drawn from concept domain DocumentSectionType"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
@@ -453,7 +417,6 @@
     </element>
     <element id="Section.component.contextConductionInd">
       <path value="Section.component.contextConductionInd"/>
-      <definition value="Element Section.component.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -466,7 +429,6 @@
     </element>
     <element id="Section.component.section">
       <path value="Section.component.section"/>
-      <definition value="Element Section.component.section"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/Section.xml
+++ b/input/resources/Section.xml
@@ -37,7 +37,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="id"/>
       </type>
     </element>
     <element id="Section.nullFlavor">

--- a/input/resources/Section.xml
+++ b/input/resources/Section.xml
@@ -53,6 +53,7 @@
       </base>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>
@@ -67,6 +68,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="DOCSECT"/>
       <fixedCode value="DOCSECT"/>
@@ -83,6 +85,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>
@@ -181,6 +184,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBJ"/>
       <fixedCode value="SBJ"/>
@@ -198,6 +202,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -255,6 +260,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INF"/>
       <fixedCode value="INF"/>
@@ -272,6 +278,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -322,6 +329,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="COMP"/>
     </element>
@@ -435,6 +443,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="COMP"/>
       <fixedCode value="COMP"/>

--- a/input/resources/ServiceEvent.xml
+++ b/input/resources/ServiceEvent.xml
@@ -27,13 +27,11 @@
   <differential>
     <element id="ServiceEvent">
       <path value="ServiceEvent"/>
-      <definition value="Element ServiceEvent"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="ServiceEvent.classCode">
       <path value="ServiceEvent.classCode"/>
-      <definition value="Element ServiceEvent.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -50,7 +48,6 @@
     </element>
     <element id="ServiceEvent.moodCode">
       <path value="ServiceEvent.moodCode"/>
-      <definition value="Element ServiceEvent.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -77,7 +74,6 @@
     </element>
     <element id="ServiceEvent.id">
       <path value="ServiceEvent.id"/>
-      <definition value="Element ServiceEvent.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -95,7 +91,6 @@
     </element>
     <element id="ServiceEvent.effectiveTime">
       <path value="ServiceEvent.effectiveTime"/>
-      <definition value="Element ServiceEvent.effectiveTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -104,7 +99,6 @@
     </element>
     <element id="ServiceEvent.performer">
       <path value="ServiceEvent.performer"/>
-      <definition value="Element ServiceEvent.performer"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/ServiceEvent.xml
+++ b/input/resources/ServiceEvent.xml
@@ -39,6 +39,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="ACT"/>
       
@@ -55,6 +56,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>

--- a/input/resources/Specimen.xml
+++ b/input/resources/Specimen.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SPC"/>
       <fixedCode value="SPC"/>

--- a/input/resources/Specimen.xml
+++ b/input/resources/Specimen.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="Specimen">
       <path value="Specimen"/>
-      <definition value="Element Specimen"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Specimen.typeCode">
       <path value="Specimen.typeCode"/>
-      <definition value="Element Specimen.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -48,7 +46,6 @@
     </element>
     <element id="Specimen.specimenRole">
       <path value="Specimen.specimenRole"/>
-      <definition value="Element Specimen.specimenRole"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/SpecimenRole.xml
+++ b/input/resources/SpecimenRole.xml
@@ -19,13 +19,11 @@
   <differential>
     <element id="SpecimenRole">
       <path value="SpecimenRole"/>
-      <definition value="Element SpecimenRole"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="SpecimenRole.classCode">
       <path value="SpecimenRole.classCode"/>
-      <definition value="Element SpecimenRole.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -51,7 +49,6 @@
     </element>
     <element id="SpecimenRole.id">
       <path value="SpecimenRole.id"/>
-      <definition value="Element SpecimenRole.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -66,7 +63,6 @@
         <valueString value="identifiedBy"/>
       </extension>
       <path value="SpecimenRole.sdtcIdentifiedBy"/>
-      <definition value="Element SpecimenRole.sdtcIdentifiedBy"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -75,7 +71,6 @@
     </element>
     <element id="SpecimenRole.specimenPlayingEntity">
       <path value="SpecimenRole.specimenPlayingEntity"/>
-      <definition value="Element SpecimenRole.specimenPlayingEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/SpecimenRole.xml
+++ b/input/resources/SpecimenRole.xml
@@ -31,6 +31,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SPEC"/>
       <fixedCode value="SPEC"/>

--- a/input/resources/StructuredBody.xml
+++ b/input/resources/StructuredBody.xml
@@ -38,6 +38,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="DOCBODY"/>
       <fixedCode value="DOCBODY"/>
@@ -55,6 +56,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="EVN"/>
       <fixedCode value="EVN"/>
@@ -103,6 +105,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="COMP"/>
       <fixedCode value="COMP"/>

--- a/input/resources/StructuredBody.xml
+++ b/input/resources/StructuredBody.xml
@@ -119,6 +119,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
       

--- a/input/resources/StructuredBody.xml
+++ b/input/resources/StructuredBody.xml
@@ -26,13 +26,11 @@
   <differential>
     <element id="StructuredBody">
       <path value="StructuredBody"/>
-      <definition value="Element StructuredBody"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="StructuredBody.classCode">
       <path value="StructuredBody.classCode"/>
-      <definition value="Element StructuredBody.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -50,7 +48,6 @@
     </element>
     <element id="StructuredBody.moodCode">
       <path value="StructuredBody.moodCode"/>
-      <definition value="Element StructuredBody.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -68,7 +65,6 @@
     </element>
     <element id="StructuredBody.confidentialityCode">
       <path value="StructuredBody.confidentialityCode"/>
-      <definition value="Element StructuredBody.confidentialityCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -77,7 +73,6 @@
     </element>
     <element id="StructuredBody.languageCode">
       <path value="StructuredBody.languageCode"/>
-      <definition value="Element StructuredBody.languageCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -90,7 +85,6 @@
     </element>
     <element id="StructuredBody.component">
       <path value="StructuredBody.component"/>
-      <definition value="Element StructuredBody.component"/>
       <min value="1"/>
       <max value="*"/>
       <type>
@@ -99,7 +93,6 @@
     </element>
     <element id="StructuredBody.component.typeCode">
       <path value="StructuredBody.component.typeCode"/>
-      <definition value="Element StructuredBody.component.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -113,7 +106,6 @@
     </element>
     <element id="StructuredBody.component.contextConductionInd">
       <path value="StructuredBody.component.contextConductionInd"/>
-      <definition value="Element StructuredBody.component.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -126,7 +118,6 @@
     </element>
     <element id="StructuredBody.component.section">
       <path value="StructuredBody.component.section"/>
-      <definition value="Element StructuredBody.component.section"/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/input/resources/SubjectPerson.xml
+++ b/input/resources/SubjectPerson.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="SubjectPerson">
       <path value="SubjectPerson"/>
-      <definition value="Element SubjectPerson"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="SubjectPerson.classCode">
       <path value="SubjectPerson.classCode"/>
-      <definition value="Element SubjectPerson.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -49,7 +47,6 @@
     </element>
     <element id="SubjectPerson.determinerCode">
       <path value="SubjectPerson.determinerCode"/>
-      <definition value="Element SubjectPerson.determinerCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -76,7 +73,6 @@
     </element>
     <element id="SubjectPerson.name">
       <path value="SubjectPerson.name"/>
-      <definition value="Element SubjectPerson.name"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -91,7 +87,6 @@
         <valueString value="desc"/>
       </extension>
       <path value="SubjectPerson.sdtcDesc"/>
-      <definition value="Element SubjectPerson.sdtcDesc"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -100,7 +95,6 @@
     </element>
     <element id="SubjectPerson.administrativeGenderCode">
       <path value="SubjectPerson.administrativeGenderCode"/>
-      <definition value="Element SubjectPerson.administrativeGenderCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -113,7 +107,6 @@
     </element>
     <element id="SubjectPerson.birthTime">
       <path value="SubjectPerson.birthTime"/>
-      <definition value="Element SubjectPerson.birthTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -128,7 +121,6 @@
         <valueString value="deceasedInd"/>
       </extension>
       <path value="SubjectPerson.sdtcDeceasedInd"/>
-      <definition value="Element SubjectPerson.sdtcDeceasedInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -143,7 +135,6 @@
         <valueString value="deceasedTime"/>
       </extension>
       <path value="SubjectPerson.sdtcDeceasedTime"/>
-      <definition value="Element SubjectPerson.sdtcDeceasedTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/input/resources/SubjectPerson.xml
+++ b/input/resources/SubjectPerson.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PSN"/>
       <fixedCode value="PSN"/>
@@ -54,6 +55,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INSTANCE"/>
       <fixedCode value="INSTANCE"/>

--- a/input/resources/SubstanceAdministration.xml
+++ b/input/resources/SubstanceAdministration.xml
@@ -28,13 +28,11 @@
   <differential>
     <element id="SubstanceAdministration">
       <path value="SubstanceAdministration"/>
-      <definition value="Element SubstanceAdministration"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="SubstanceAdministration.classCode">
       <path value="SubstanceAdministration.classCode"/>
-      <definition value="Element SubstanceAdministration.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -51,7 +49,6 @@
     </element>
     <element id="SubstanceAdministration.moodCode">
       <path value="SubstanceAdministration.moodCode"/>
-      <definition value="Element SubstanceAdministration.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -62,7 +59,6 @@
     </element>
     <element id="SubstanceAdministration.realmCode">
       <path value="SubstanceAdministration.realmCode"/>
-      <definition value="Element SubstanceAdministration.realmCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -71,7 +67,6 @@
     </element>
     <element id="SubstanceAdministration.typeId">
       <path value="SubstanceAdministration.typeId"/>
-      <definition value="Element SubstanceAdministration.typeId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -89,7 +84,6 @@
     </element>
     <element id="SubstanceAdministration.id">
       <path value="SubstanceAdministration.id"/>
-      <definition value="Element SubstanceAdministration.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -98,7 +92,6 @@
     </element>
     <element id="SubstanceAdministration.code">
       <path value="SubstanceAdministration.code"/>
-      <definition value="Element SubstanceAdministration.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -111,7 +104,6 @@
     </element>
     <element id="SubstanceAdministration.negationInd">
       <path value="SubstanceAdministration.negationInd"/>
-      <definition value="Element SubstanceAdministration.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -122,7 +114,6 @@
     </element>
     <element id="SubstanceAdministration.text">
       <path value="SubstanceAdministration.text"/>
-      <definition value="Element SubstanceAdministration.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -131,7 +122,6 @@
     </element>
     <element id="SubstanceAdministration.statusCode">
       <path value="SubstanceAdministration.statusCode"/>
-      <definition value="Element SubstanceAdministration.statusCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -147,7 +137,6 @@
         <valueCanonical value="http://hl7.org/cda/stds/core/StructureDefinition/SXCM-TS"/>
       </extension>
       <path value="SubstanceAdministration.effectiveTime"/>
-      <definition value="Element SubstanceAdministration.effectiveTime"/>
       <representation value="typeAttr"/>
       <min value="0"/>
       <max value="*"/>
@@ -169,7 +158,6 @@
     </element>
     <element id="SubstanceAdministration.priorityCode">
       <path value="SubstanceAdministration.priorityCode"/>
-      <definition value="Element SubstanceAdministration.priorityCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -182,7 +170,6 @@
     </element>
     <element id="SubstanceAdministration.repeatNumber">
       <path value="SubstanceAdministration.repeatNumber"/>
-      <definition value="Element SubstanceAdministration.repeatNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -191,7 +178,6 @@
     </element>
     <element id="SubstanceAdministration.routeCode">
       <path value="SubstanceAdministration.routeCode"/>
-      <definition value="Element SubstanceAdministration.routeCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -204,7 +190,6 @@
     </element>
     <element id="SubstanceAdministration.approachSiteCode">
       <path value="SubstanceAdministration.approachSiteCode"/>
-      <definition value="Element SubstanceAdministration.approachSiteCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -217,7 +202,6 @@
     </element>
     <element id="SubstanceAdministration.doseQuantity">
       <path value="SubstanceAdministration.doseQuantity"/>
-      <definition value="Element SubstanceAdministration.doseQuantity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -226,7 +210,6 @@
     </element>
     <element id="SubstanceAdministration.rateQuantity">
       <path value="SubstanceAdministration.rateQuantity"/>
-      <definition value="Element SubstanceAdministration.rateQuantity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -235,7 +218,6 @@
     </element>
     <element id="SubstanceAdministration.maxDoseQuantity">
       <path value="SubstanceAdministration.maxDoseQuantity"/>
-      <definition value="Element SubstanceAdministration.maxDoseQuantity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -244,7 +226,6 @@
     </element>
     <element id="SubstanceAdministration.administrationUnitCode">
       <path value="SubstanceAdministration.administrationUnitCode"/>
-      <definition value="Element SubstanceAdministration.administrationUnitCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -257,7 +238,6 @@
     </element>
     <element id="SubstanceAdministration.consumable">
       <path value="SubstanceAdministration.consumable"/>
-      <definition value="Element SubstanceAdministration.consumable"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -266,7 +246,6 @@
     </element>
     <element id="SubstanceAdministration.consumable.typeCode">
       <path value="SubstanceAdministration.consumable.typeCode"/>
-      <definition value="Element SubstanceAdministration.consumable.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -284,7 +263,6 @@
     </element>
     <element id="SubstanceAdministration.consumable.manufacturedProduct">
       <path value="SubstanceAdministration.consumable.manufacturedProduct"/>
-      <definition value="Element SubstanceAdministration.consumable.manufacturedProduct"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -293,7 +271,6 @@
     </element>
     <element id="SubstanceAdministration.subject">
       <path value="SubstanceAdministration.subject"/>
-      <definition value="Element SubstanceAdministration.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -302,7 +279,6 @@
     </element>
     <element id="SubstanceAdministration.subject.typeCode">
       <path value="SubstanceAdministration.subject.typeCode"/>
-      <definition value="Element SubstanceAdministration.subject.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -320,7 +296,6 @@
     </element>
     <element id="SubstanceAdministration.subject.contextControlCode">
       <path value="SubstanceAdministration.subject.contextControlCode"/>
-      <definition value="Element SubstanceAdministration.subject.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -338,7 +313,6 @@
     </element>
     <element id="SubstanceAdministration.subject.awarenessCode">
       <path value="SubstanceAdministration.subject.awarenessCode"/>
-      <definition value="Element SubstanceAdministration.subject.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -351,7 +325,6 @@
     </element>
     <element id="SubstanceAdministration.subject.relatedSubject">
       <path value="SubstanceAdministration.subject.relatedSubject"/>
-      <definition value="Element SubstanceAdministration.subject.relatedSubject"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -360,7 +333,6 @@
     </element>
     <element id="SubstanceAdministration.specimen">
       <path value="SubstanceAdministration.specimen"/>
-      <definition value="Element SubstanceAdministration.specimen"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -369,7 +341,6 @@
     </element>
     <element id="SubstanceAdministration.performer">
       <path value="SubstanceAdministration.performer"/>
-      <definition value="Element SubstanceAdministration.performer"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -378,7 +349,6 @@
     </element>
     <element id="SubstanceAdministration.author">
       <path value="SubstanceAdministration.author"/>
-      <definition value="Element SubstanceAdministration.author"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -387,7 +357,6 @@
     </element>
     <element id="SubstanceAdministration.informant">
       <path value="SubstanceAdministration.informant"/>
-      <definition value="Element SubstanceAdministration.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -396,7 +365,6 @@
     </element>
     <element id="SubstanceAdministration.informant.typeCode">
       <path value="SubstanceAdministration.informant.typeCode"/>
-      <definition value="Element SubstanceAdministration.informant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -414,7 +382,6 @@
     </element>
     <element id="SubstanceAdministration.informant.contextControlCode">
       <path value="SubstanceAdministration.informant.contextControlCode"/>
-      <definition value="Element SubstanceAdministration.informant.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -432,7 +399,6 @@
     </element>
     <element id="SubstanceAdministration.informant.assignedEntity">
       <path value="SubstanceAdministration.informant.assignedEntity"/>
-      <definition value="Element SubstanceAdministration.informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -441,7 +407,6 @@
     </element>
     <element id="SubstanceAdministration.informant.relatedEntity">
       <path value="SubstanceAdministration.informant.relatedEntity"/>
-      <definition value="Element SubstanceAdministration.informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -450,7 +415,6 @@
     </element>
     <element id="SubstanceAdministration.participant">
       <path value="SubstanceAdministration.participant"/>
-      <definition value="Element SubstanceAdministration.participant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -459,7 +423,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship">
       <path value="SubstanceAdministration.entryRelationship"/>
-      <definition value="Element SubstanceAdministration.entryRelationship"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -475,7 +438,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.typeCode">
       <path value="SubstanceAdministration.entryRelationship.typeCode"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -487,7 +449,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.inversionInd">
       <path value="SubstanceAdministration.entryRelationship.inversionInd"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.inversionInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -498,7 +459,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.contextConductionInd">
       <path value="SubstanceAdministration.entryRelationship.contextConductionInd"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -511,7 +471,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.sequenceNumber">
       <path value="SubstanceAdministration.entryRelationship.sequenceNumber"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.sequenceNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -520,7 +479,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.negationInd">
       <path value="SubstanceAdministration.entryRelationship.negationInd"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -531,7 +489,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.seperatableInd">
       <path value="SubstanceAdministration.entryRelationship.seperatableInd"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -540,7 +497,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.observation">
       <path value="SubstanceAdministration.entryRelationship.observation"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.observation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -549,7 +505,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.regionOfInterest">
       <path value="SubstanceAdministration.entryRelationship.regionOfInterest"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.regionOfInterest"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -558,7 +513,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.observationMedia">
       <path value="SubstanceAdministration.entryRelationship.observationMedia"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.observationMedia"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -567,7 +521,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.substanceAdministration">
       <path value="SubstanceAdministration.entryRelationship.substanceAdministration"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.substanceAdministration"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -576,7 +529,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.supply">
       <path value="SubstanceAdministration.entryRelationship.supply"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.supply"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -585,7 +537,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.procedure">
       <path value="SubstanceAdministration.entryRelationship.procedure"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.procedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -594,7 +545,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.encounter">
       <path value="SubstanceAdministration.entryRelationship.encounter"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.encounter"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -603,7 +553,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.organizer">
       <path value="SubstanceAdministration.entryRelationship.organizer"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.organizer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -612,7 +561,6 @@
     </element>
     <element id="SubstanceAdministration.entryRelationship.act">
       <path value="SubstanceAdministration.entryRelationship.act"/>
-      <definition value="Element SubstanceAdministration.entryRelationship.act"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -621,7 +569,6 @@
     </element>
     <element id="SubstanceAdministration.reference">
       <path value="SubstanceAdministration.reference"/>
-      <definition value="Element SubstanceAdministration.reference"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -630,7 +577,6 @@
     </element>
     <element id="SubstanceAdministration.reference.typeCode">
       <path value="SubstanceAdministration.reference.typeCode"/>
-      <definition value="Element SubstanceAdministration.reference.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -642,7 +588,6 @@
     </element>
     <element id="SubstanceAdministration.reference.seperatableInd">
       <path value="SubstanceAdministration.reference.seperatableInd"/>
-      <definition value="Element SubstanceAdministration.reference.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -651,7 +596,6 @@
     </element>
     <element id="SubstanceAdministration.reference.externalAct">
       <path value="SubstanceAdministration.reference.externalAct"/>
-      <definition value="Element SubstanceAdministration.reference.externalAct"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -660,7 +604,6 @@
     </element>
     <element id="SubstanceAdministration.reference.externalObservation">
       <path value="SubstanceAdministration.reference.externalObservation"/>
-      <definition value="Element SubstanceAdministration.reference.externalObservation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -669,7 +612,6 @@
     </element>
     <element id="SubstanceAdministration.reference.externalProcedure">
       <path value="SubstanceAdministration.reference.externalProcedure"/>
-      <definition value="Element SubstanceAdministration.reference.externalProcedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -678,7 +620,6 @@
     </element>
     <element id="SubstanceAdministration.reference.externalDocument">
       <path value="SubstanceAdministration.reference.externalDocument"/>
-      <definition value="Element SubstanceAdministration.reference.externalDocument"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -687,7 +628,6 @@
     </element>
     <element id="SubstanceAdministration.precondition">
       <path value="SubstanceAdministration.precondition"/>
-      <definition value="Element SubstanceAdministration.precondition"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/SubstanceAdministration.xml
+++ b/input/resources/SubstanceAdministration.xml
@@ -117,6 +117,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="SubstanceAdministration.text">
@@ -492,6 +493,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="SubstanceAdministration.entryRelationship.contextConductionInd">
@@ -502,6 +504,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
       
@@ -523,6 +526,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="SubstanceAdministration.entryRelationship.seperatableInd">

--- a/input/resources/SubstanceAdministration.xml
+++ b/input/resources/SubstanceAdministration.xml
@@ -40,6 +40,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBADM"/>
       <fixedCode value="SBADM"/>
@@ -56,6 +57,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="SubstanceAdministration.realmCode">
@@ -269,6 +271,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="CSM"/>
       <fixedCode value="CSM"/>
@@ -304,6 +307,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBJ"/>
       <fixedCode value="SBJ"/>
@@ -321,6 +325,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -396,6 +401,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INF"/>
       <fixedCode value="INF"/>
@@ -413,6 +419,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -473,6 +480,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>
@@ -624,6 +632,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>

--- a/input/resources/Supply.xml
+++ b/input/resources/Supply.xml
@@ -27,13 +27,11 @@
   <differential>
     <element id="Supply">
       <path value="Supply"/>
-      <definition value="Element Supply"/>
       <min value="1"/>
       <max value="1"/>
     </element>
     <element id="Supply.classCode">
       <path value="Supply.classCode"/>
-      <definition value="Element Supply.classCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -50,7 +48,6 @@
     </element>
     <element id="Supply.moodCode">
       <path value="Supply.moodCode"/>
-      <definition value="Element Supply.moodCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -61,7 +58,6 @@
     </element>
     <element id="Supply.realmCode">
       <path value="Supply.realmCode"/>
-      <definition value="Element Supply.realmCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -70,7 +66,6 @@
     </element>
     <element id="Supply.typeId">
       <path value="Supply.typeId"/>
-      <definition value="Element Supply.typeId"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -88,7 +83,6 @@
     </element>
     <element id="Supply.id">
       <path value="Supply.id"/>
-      <definition value="Element Supply.id"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -97,7 +91,6 @@
     </element>
     <element id="Supply.code">
       <path value="Supply.code"/>
-      <definition value="Element Supply.code"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -110,7 +103,6 @@
     </element>
     <element id="Supply.text">
       <path value="Supply.text"/>
-      <definition value="Element Supply.text"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -119,7 +111,6 @@
     </element>
     <element id="Supply.statusCode">
       <path value="Supply.statusCode"/>
-      <definition value="Element Supply.statusCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -135,7 +126,6 @@
         <valueCanonical value="http://hl7.org/cda/stds/core/StructureDefinition/SXCM-TS"/>
       </extension>
       <path value="Supply.effectiveTime"/>
-      <definition value="Element Supply.effectiveTime"/>
       <representation value="typeAttr"/>
       <min value="0"/>
       <max value="*"/>
@@ -157,7 +147,6 @@
     </element>
     <element id="Supply.priorityCode">
       <path value="Supply.priorityCode"/>
-      <definition value="Element Supply.priorityCode"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -170,7 +159,6 @@
     </element>
     <element id="Supply.repeatNumber">
       <path value="Supply.repeatNumber"/>
-      <definition value="Element Supply.repeatNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -179,7 +167,6 @@
     </element>
     <element id="Supply.independentInd">
       <path value="Supply.independentInd"/>
-      <definition value="Element Supply.independentInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -188,7 +175,6 @@
     </element>
     <element id="Supply.quantity">
       <path value="Supply.quantity"/>
-      <definition value="Element Supply.quantity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -197,7 +183,6 @@
     </element>
     <element id="Supply.expectedUseTime">
       <path value="Supply.expectedUseTime"/>
-      <definition value="Element Supply.expectedUseTime"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -206,7 +191,6 @@
     </element>
     <element id="Supply.product">
       <path value="Supply.product"/>
-      <definition value="Element Supply.product"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -216,7 +200,6 @@
     </element>
     <element id="Supply.product.typeCode">
       <path value="Supply.product.typeCode"/>
-      <definition value="Element Supply.product.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -234,7 +217,6 @@
     </element>
     <element id="Supply.product.manufacturedProduct">
       <path value="Supply.product.manufacturedProduct"/>
-      <definition value="Element Supply.product.manufacturedProduct"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -244,7 +226,6 @@
     </element>
     <element id="Supply.subject">
       <path value="Supply.subject"/>
-      <definition value="Element Supply.subject"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -253,7 +234,6 @@
     </element>
     <element id="Supply.subject.typeCode">
       <path value="Supply.subject.typeCode"/>
-      <definition value="Element Supply.subject.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -271,7 +251,6 @@
     </element>
     <element id="Supply.subject.contextControlCode">
       <path value="Supply.subject.contextControlCode"/>
-      <definition value="Element Supply.subject.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -289,7 +268,6 @@
     </element>
     <element id="Supply.subject.awarenessCode">
       <path value="Supply.subject.awarenessCode"/>
-      <definition value="Element Supply.subject.awarenessCode"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -302,7 +280,6 @@
     </element>
     <element id="Supply.subject.relatedSubject">
       <path value="Supply.subject.relatedSubject"/>
-      <definition value="Element Supply.subject.relatedSubject"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -311,7 +288,6 @@
     </element>
     <element id="Supply.specimen">
       <path value="Supply.specimen"/>
-      <definition value="Element Supply.specimen"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -320,7 +296,6 @@
     </element>
     <element id="Supply.performer">
       <path value="Supply.performer"/>
-      <definition value="Element Supply.performer"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -329,7 +304,6 @@
     </element>
     <element id="Supply.author">
       <path value="Supply.author"/>
-      <definition value="Element Supply.author"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -338,7 +312,6 @@
     </element>
     <element id="Supply.informant">
       <path value="Supply.informant"/>
-      <definition value="Element Supply.informant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -347,7 +320,6 @@
     </element>
     <element id="Supply.informant.typeCode">
       <path value="Supply.informant.typeCode"/>
-      <definition value="Element Supply.informant.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -365,7 +337,6 @@
     </element>
     <element id="Supply.informant.contextControlCode">
       <path value="Supply.informant.contextControlCode"/>
-      <definition value="Element Supply.informant.contextControlCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -383,7 +354,6 @@
     </element>
     <element id="Supply.informant.assignedEntity">
       <path value="Supply.informant.assignedEntity"/>
-      <definition value="Element Supply.informant.assignedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -392,7 +362,6 @@
     </element>
     <element id="Supply.informant.relatedEntity">
       <path value="Supply.informant.relatedEntity"/>
-      <definition value="Element Supply.informant.relatedEntity"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -401,7 +370,6 @@
     </element>
     <element id="Supply.participant">
       <path value="Supply.participant"/>
-      <definition value="Element Supply.participant"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -410,7 +378,6 @@
     </element>
     <element id="Supply.entryRelationship">
       <path value="Supply.entryRelationship"/>
-      <definition value="Element Supply.entryRelationship"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -426,7 +393,6 @@
     </element>
     <element id="Supply.entryRelationship.typeCode">
       <path value="Supply.entryRelationship.typeCode"/>
-      <definition value="Element Supply.entryRelationship.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -438,7 +404,6 @@
     </element>
     <element id="Supply.entryRelationship.inversionInd">
       <path value="Supply.entryRelationship.inversionInd"/>
-      <definition value="Element Supply.entryRelationship.inversionInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -449,7 +414,6 @@
     </element>
     <element id="Supply.entryRelationship.contextConductionInd">
       <path value="Supply.entryRelationship.contextConductionInd"/>
-      <definition value="Element Supply.entryRelationship.contextConductionInd"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -462,7 +426,6 @@
     </element>
     <element id="Supply.entryRelationship.sequenceNumber">
       <path value="Supply.entryRelationship.sequenceNumber"/>
-      <definition value="Element Supply.entryRelationship.sequenceNumber"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -471,7 +434,6 @@
     </element>
     <element id="Supply.entryRelationship.negationInd">
       <path value="Supply.entryRelationship.negationInd"/>
-      <definition value="Element Supply.entryRelationship.negationInd"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
@@ -482,7 +444,6 @@
     </element>
     <element id="Supply.entryRelationship.seperatableInd">
       <path value="Supply.entryRelationship.seperatableInd"/>
-      <definition value="Element Supply.entryRelationship.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -491,7 +452,6 @@
     </element>
     <element id="Supply.entryRelationship.observation">
       <path value="Supply.entryRelationship.observation"/>
-      <definition value="Element Supply.entryRelationship.observation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -500,7 +460,6 @@
     </element>
     <element id="Supply.entryRelationship.regionOfInterest">
       <path value="Supply.entryRelationship.regionOfInterest"/>
-      <definition value="Element Supply.entryRelationship.regionOfInterest"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -509,7 +468,6 @@
     </element>
     <element id="Supply.entryRelationship.observationMedia">
       <path value="Supply.entryRelationship.observationMedia"/>
-      <definition value="Element Supply.entryRelationship.observationMedia"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -518,7 +476,6 @@
     </element>
     <element id="Supply.entryRelationship.substanceAdministration">
       <path value="Supply.entryRelationship.substanceAdministration"/>
-      <definition value="Element Supply.entryRelationship.substanceAdministration"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -527,7 +484,6 @@
     </element>
     <element id="Supply.entryRelationship.supply">
       <path value="Supply.entryRelationship.supply"/>
-      <definition value="Element Supply.entryRelationship.supply"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -536,7 +492,6 @@
     </element>
     <element id="Supply.entryRelationship.procedure">
       <path value="Supply.entryRelationship.procedure"/>
-      <definition value="Element Supply.entryRelationship.procedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -545,7 +500,6 @@
     </element>
     <element id="Supply.entryRelationship.encounter">
       <path value="Supply.entryRelationship.encounter"/>
-      <definition value="Element Supply.entryRelationship.encounter"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -554,7 +508,6 @@
     </element>
     <element id="Supply.entryRelationship.organizer">
       <path value="Supply.entryRelationship.organizer"/>
-      <definition value="Element Supply.entryRelationship.organizer"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -563,7 +516,6 @@
     </element>
     <element id="Supply.entryRelationship.act">
       <path value="Supply.entryRelationship.act"/>
-      <definition value="Element Supply.entryRelationship.act"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -572,7 +524,6 @@
     </element>
     <element id="Supply.reference">
       <path value="Supply.reference"/>
-      <definition value="Element Supply.reference"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -581,7 +532,6 @@
     </element>
     <element id="Supply.reference.typeCode">
       <path value="Supply.reference.typeCode"/>
-      <definition value="Element Supply.reference.typeCode"/>
       <representation value="xmlAttr"/>
       <min value="1"/>
       <max value="1"/>
@@ -593,7 +543,6 @@
     </element>
     <element id="Supply.reference.seperatableInd">
       <path value="Supply.reference.seperatableInd"/>
-      <definition value="Element Supply.reference.seperatableInd"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -602,7 +551,6 @@
     </element>
     <element id="Supply.reference.externalAct">
       <path value="Supply.reference.externalAct"/>
-      <definition value="Element Supply.reference.externalAct"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -611,7 +559,6 @@
     </element>
     <element id="Supply.reference.externalObservation">
       <path value="Supply.reference.externalObservation"/>
-      <definition value="Element Supply.reference.externalObservation"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -620,7 +567,6 @@
     </element>
     <element id="Supply.reference.externalProcedure">
       <path value="Supply.reference.externalProcedure"/>
-      <definition value="Element Supply.reference.externalProcedure"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -629,7 +575,6 @@
     </element>
     <element id="Supply.reference.externalDocument">
       <path value="Supply.reference.externalDocument"/>
-      <definition value="Element Supply.reference.externalDocument"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -638,7 +583,6 @@
     </element>
     <element id="Supply.precondition">
       <path value="Supply.precondition"/>
-      <definition value="Element Supply.precondition"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/input/resources/Supply.xml
+++ b/input/resources/Supply.xml
@@ -444,6 +444,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Supply.entryRelationship.contextConductionInd">
@@ -454,6 +455,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
       <defaultValueBoolean value="true"/>
       
@@ -475,6 +477,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
     <element id="Supply.entryRelationship.seperatableInd">

--- a/input/resources/Supply.xml
+++ b/input/resources/Supply.xml
@@ -39,6 +39,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SPLY"/>
       <fixedCode value="SPLY"/>
@@ -55,6 +56,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
     <element id="Supply.realmCode">
@@ -220,6 +222,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="PRD"/>
       <fixedCode value="PRD"/>
@@ -256,6 +259,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="SBJ"/>
       <fixedCode value="SBJ"/>
@@ -273,6 +277,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -348,6 +353,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="INF"/>
       <fixedCode value="INF"/>
@@ -365,6 +371,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <defaultValueCode value="OP"/>
       <fixedCode value="OP"/>
@@ -425,6 +432,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>
@@ -576,6 +584,7 @@
       <max value="1"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       
     </element>

--- a/input/resources/TEL.xml
+++ b/input/resources/TEL.xml
@@ -25,13 +25,11 @@
   <differential>
     <element id="TEL">
       <path value="TEL"/>
-      <definition value="Element TEL"/>
       <min value="1"/>
       <max value="*"/>
     </element>
     <element id="TEL.value">
       <path value="TEL.value"/>
-      <definition value="Element TEL.value"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>

--- a/input/resources/TEL.xml
+++ b/input/resources/TEL.xml
@@ -37,6 +37,7 @@
       <max value="1"/>
       <type>
         <code value="uri"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/url"/>
       </type>
     </element>
     <element id="TEL.useablePeriod">

--- a/input/resources/TEL.xml
+++ b/input/resources/TEL.xml
@@ -36,7 +36,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="uri"/>
+        <code value="url"/>
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/url"/>
       </type>
     </element>

--- a/input/resources/TEL.xml
+++ b/input/resources/TEL.xml
@@ -71,6 +71,7 @@
       <max value="*"/>
       <type>
         <code value="code"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
       <binding>
         <strength value="required"/>

--- a/input/resources/TN.xml
+++ b/input/resources/TN.xml
@@ -28,14 +28,12 @@
   <differential>
     <element id="EN">
       <path value="EN"/>
-      <definition value="Element EN"/>
       <definition value="A restriction of entity name that is effectively a simple string used for a simple name for things and places."/>
       <min value="1"/>
       <max value="*"/>
     </element>
     <element id="EN.use">
       <path value="EN.use"/>
-      <definition value="Element EN.use"/>
       <binding>
         <strength value="required"/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-EntityNameUse"/>
@@ -43,31 +41,26 @@
     </element>
     <element id="EN.delimiter">
       <path value="EN.delimiter"/>
-      <definition value="Element EN.delimiter"/>
       <min value="0"/>
       <max value="0"/>
     </element>
     <element id="EN.family">
       <path value="EN.family"/>
-      <definition value="Element EN.family"/>
       <min value="0"/>
       <max value="0"/>
     </element>
     <element id="EN.given">
       <path value="EN.given"/>
-      <definition value="Element EN.given"/>
       <min value="0"/>
       <max value="0"/>
     </element>
     <element id="EN.prefix">
       <path value="EN.prefix"/>
-      <definition value="Element EN.prefix"/>
       <min value="0"/>
       <max value="0"/>
     </element>
     <element id="EN.suffix">
       <path value="EN.suffix"/>
-      <definition value="Element EN.suffix"/>
       <min value="0"/>
       <max value="0"/>
     </element>

--- a/input/resources/TS.xml
+++ b/input/resources/TS.xml
@@ -39,7 +39,8 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="dateTime"/>
+        <code value="string"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/ts-simple"/>
       </type>
     </element>
     <element id="TS.inclusive">

--- a/input/resources/TS.xml
+++ b/input/resources/TS.xml
@@ -50,6 +50,7 @@
       <max value="1"/>
       <type>
         <code value="boolean"/>
+        <profile value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
       </type>
     </element>
   </differential>

--- a/input/resources/bin.xml
+++ b/input/resources/bin.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="bin"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'bin'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/bin"/>
+  <name value="bin"/>
+  <title value="bin: Binary Data"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="Binary data is a raw block of bits. Binary data is a protected type that MUST not be used outside the data type specification."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="base64Binary"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/base64Binary"/>
+  <derivation value="constraint"/> 
+  <differential>
+    <element id="base64Binary.id">
+      <path value="base64Binary.id"/>
+      <max value="0"/>
+    </element>
+    <element id="base64Binary.extension">
+      <path value="base64Binary.extension"/>
+      <max value="0"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/bl-simple.xml
+++ b/input/resources/bl-simple.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="bl-simple"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'bl'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/bl-simple"/>
+  <name value="bl"/>
+  <title value="bl: Boolean"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="The Boolean type stands for the values of two-valued logic. A Boolean value can be either true or false."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="boolean"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/boolean"/>
+  <derivation value="constraint"/> 
+  <differential>
+    <element id="boolean.id">
+      <path value="boolean.id"/>
+      <max value="0"/>
+    </element>
+    <element id="boolean.extension">
+      <path value="boolean.extension"/>
+      <max value="0"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/bn.xml
+++ b/input/resources/bn.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="bn"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'bn'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/bn"/>
+  <name value="bn"/>
+  <title value="bn: BooleanNonNull"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="The BooleanNonNull type is used where a Boolean cannot have a null value. A Boolean value can be either true or false."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="boolean"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/boolean"/>
+  <derivation value="constraint"/> 
+  <differential>
+    <element id="boolean.id">
+      <path value="boolean.id"/>
+      <max value="0"/>
+    </element>
+    <element id="boolean.extension">
+      <path value="boolean.extension"/>
+      <max value="0"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/cs-simple.xml
+++ b/input/resources/cs-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="cs-prim"/>
+  <id value="cs-simple"/>
   <text>
     <status value="generated"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
@@ -10,23 +10,36 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
     <valueUri value="urn:hl7-org:v3"/>
   </extension>
-  <url value="http://hl7.org/cda/stds/core/StructureDefinition/cs-prim"/>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
   <name value="cs"/>
-  <title value="cs primitive (wrapper for code)"/>
+  <title value="cs: Coded Simple Value"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>
-  <description value="cs primitive"/>
+  <description value="Coded data in its simplest form, consists of a code. The code system and code system version is fixed by the context in which the value occurs. 'cs' is used for coded attributes that have a single HL7-defined value set."/>
   <kind value="primitive-type"/>
   <abstract value="false"/>
   <type value="code"/>
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/code"/>
   <derivation value="constraint"/>
   <differential>
+    <element id="code.id">
+      <path value="code.id"/>
+      <max value="0"/>
+    </element>
     <element id="code.extension">
       <path value="code.extension"/>
-      <definition value="Element code.extension"/>
       <max value="0"/>
+    </element>
+    <element id="code.value">
+      <path value="code.value"/>
+      <representation value="xmlAttr"/>
+      <constraint>
+        <key value="cs-value"/>
+        <severity value="error"/>
+        <human value="cs attributes must not contain any whitespace"/>
+        <expression value="matches('^[^/s]+$')"/>
+      </constraint>
     </element>
   </differential>
 </StructureDefinition>

--- a/input/resources/cs-simple.xml
+++ b/input/resources/cs-simple.xml
@@ -38,7 +38,7 @@
         <key value="cs-value"/>
         <severity value="error"/>
         <human value="cs attributes must not contain any whitespace"/>
-        <expression value="matches('^[^/s]+$')"/>
+        <expression value="matches('^[^\\s]+$')"/>
       </constraint>
     </element>
   </differential>

--- a/input/resources/int-simple.xml
+++ b/input/resources/int-simple.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="int-simple"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'int'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/int-simple"/>
+  <name value="int"/>
+  <title value="int: Integer Number"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="Integer numbers (-1,0,1,2, 100, 3398129, etc.) are precise numbers that are results of counting and enumerating. Integer numbers are discrete, the set of integers is infinite but countable.  No arbitrary limit is imposed on the range of integer numbers. Two NULL flavors are defined for the positive and negative infinity."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="integer"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/integer"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="integer.id">
+      <path value="integer.id"/>
+      <max value="0"/>
+    </element>
+    <element id="integer.extension">
+      <path value="integer.extension"/>
+      <max value="0"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/oid.xml
+++ b/input/resources/oid.xml
@@ -19,22 +19,22 @@
   <description value="A globally unique string representing an ISO Object Identifier (OID) in a form that consists only of numbers and dots (e.g., '2.16.840.1.113883.3.1')."/>
   <kind value="primitive-type"/>
   <abstract value="false"/>
-  <type value="string"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/string"/>
+  <type value="id"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/id"/>
   <derivation value="constraint"/> 
   <differential>
-    <element id="string.id">
-      <path value="string.id"/>
+    <element id="id.id">
+      <path value="id.id"/>
       <max value="0"/>
     </element>
-    <element id="string.extension">
-      <path value="string.extension"/>
+    <element id="id.extension">
+      <path value="id.extension"/>
       <max value="0"/>
     </element>
-    <element id="string.value">
-      <path value="string.value"/>
+    <element id="id.value">
+      <path value="id.value"/>
       <constraint>
-        <key value="uid-value"/>
+        <key value="oid-value"/>
         <severity value="error"/>
         <human value="Must conform to OID (#.#.#), UUID (32 hexadecimal digits separated by hyphens), or RUID (a letter followed by any combination of letters, numbers or hyphens)"/>
         <expression value="matches('^[0-2](/.(0|[1-9][0-9]*))+$')"/>

--- a/input/resources/oid.xml
+++ b/input/resources/oid.xml
@@ -37,7 +37,7 @@
         <key value="oid-value"/>
         <severity value="error"/>
         <human value="Must conform to OID (#.#.#), UUID (32 hexadecimal digits separated by hyphens), or RUID (a letter followed by any combination of letters, numbers or hyphens)"/>
-        <expression value="matches('^[0-2](/.(0|[1-9][0-9]*))+$')"/>
+        <expression value="matches('^[0-2](\\.(0|[1-9][0-9]*))+$')"/>
       </constraint>
     </element>
   </differential>

--- a/input/resources/oid.xml
+++ b/input/resources/oid.xml
@@ -19,20 +19,20 @@
   <description value="A globally unique string representing an ISO Object Identifier (OID) in a form that consists only of numbers and dots (e.g., '2.16.840.1.113883.3.1')."/>
   <kind value="primitive-type"/>
   <abstract value="false"/>
-  <type value="id"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/id"/>
+  <type value="string"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/string"/>
   <derivation value="constraint"/> 
   <differential>
-    <element id="id.id">
-      <path value="id.id"/>
+    <element id="string.id">
+      <path value="string.id"/>
       <max value="0"/>
     </element>
-    <element id="id.extension">
-      <path value="id.extension"/>
+    <element id="string.extension">
+      <path value="string.extension"/>
       <max value="0"/>
     </element>
-    <element id="id.value">
-      <path value="id.value"/>
+    <element id="string.value">
+      <path value="string.value"/>
       <constraint>
         <key value="oid-value"/>
         <severity value="error"/>

--- a/input/resources/oid.xml
+++ b/input/resources/oid.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="oid"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'oid'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/oid"/>
+  <name value="oid"/>
+  <title value="oid: ISO Object Identifier"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="A globally unique string representing an ISO Object Identifier (OID) in a form that consists only of numbers and dots (e.g., '2.16.840.1.113883.3.1')."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="string"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/string"/>
+  <derivation value="constraint"/> 
+  <differential>
+    <element id="string.id">
+      <path value="string.id"/>
+      <max value="0"/>
+    </element>
+    <element id="string.extension">
+      <path value="string.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="string.value">
+      <path value="string.value"/>
+      <constraint>
+        <key value="uid-value"/>
+        <severity value="error"/>
+        <human value="Must conform to OID (#.#.#), UUID (32 hexadecimal digits separated by hyphens), or RUID (a letter followed by any combination of letters, numbers or hyphens)"/>
+        <expression value="matches('^[0-2](/.(0|[1-9][0-9]*))+$')"/>
+      </constraint>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/probability.xml
+++ b/input/resources/probability.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="probability"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'probability'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/probability"/>
+  <name value="probability"/>
+  <title value="probability: Probability"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="The probability assigned to the value, a decimal number between 0 (very uncertain) and 1 (certain)."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="decimal"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/decimal"/>
+  <derivation value="constraint"/> 
+  <differential>
+    <element id="decimal.id">
+      <path value="decimal.id"/>
+      <max value="0"/>
+    </element>
+    <element id="decimal.extension">
+      <path value="decimal.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="decimal.value">
+      <path value="decimal.value"/>
+      <minValueDecimal value="0.0"/>
+      <maxValueDecimal value="1.0"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/real-simple.xml
+++ b/input/resources/real-simple.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="real-simple"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'real'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/real-simple"/>
+  <name value="real"/>
+  <title value="real: Real Number"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="Fractional numbers. Typically used whenever quantities are measured, estimated, or computed from other real numbers.  The typical representation is decimal, where the number of significant decimal digits is known as the precision. Real numbers are needed beyond integers whenever quantities of the real world are measured, estimated, or computed from other real numbers. The term &quot;Real number&quot; in this specification is used to mean that fractional values are covered without necessarily implying the full set of the mathematical real numbers."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="decimal"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/decimal"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="decimal.id">
+      <path value="decimal.id"/>
+      <max value="0"/>
+    </element>
+    <element id="decimal.extension">
+      <path value="decimal.extension"/>
+      <max value="0"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/ruid.xml
+++ b/input/resources/ruid.xml
@@ -38,7 +38,7 @@
         <key value="ruid-value"/>
         <severity value="error"/>
         <human value="An identifier that starts with a letter and contains any combination of letters, numbers, and hyphen."/>
-        <expression value="matches('^[A-Za-z][A-Za-z0-9/-]*$')"/>
+        <expression value="matches('^[A-Za-z][A-Za-z0-9\\-]*$')"/>
       </constraint>
     </element>
   </differential>

--- a/input/resources/ruid.xml
+++ b/input/resources/ruid.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ruid"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'ruid'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/ruid"/>
+  <name value="ruid"/>
+  <title value="ruid: HL7 Reserved Identifier Scheme"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="HL7 Reserved Identifier Scheme (RUID)\nA globally unique string defined exclusively by HL7. Identifiers in this scheme are only defined by balloted HL7 specifications. Local communities or systems must never use such reserved identifiers based on bilateral negotiations.\n\nHL7 reserved identifiers are strings that consist only of (US-ASCII) letters, digits and hyphens, where the first character must be a letter. HL7 may assign these reserved identifiers as mnemonic identifiers for major concepts of interest to HL7."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="id"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/id"/>
+  <derivation value="constraint"/> 
+  <differential>
+    <element id="id.id">
+      <path value="id.id"/>
+      <min value="0"/>
+    </element>
+    <element id="id.extension">
+      <path value="id.extension"/>
+      <min value="0"/>
+    </element>
+    <element id="id.value">
+      <path value="id.value"/>
+      <representation value="xmlAttr"/>
+      <constraint>
+        <key value="ruid-value"/>
+        <severity value="error"/>
+        <human value="An identifier that starts with a letter and contains any combination of letters, numbers, and hyphen."/>
+        <expression value="matches('^[A-Za-z][A-Za-z0-9/-]*$')"/>
+      </constraint>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/ruid.xml
+++ b/input/resources/ruid.xml
@@ -19,20 +19,20 @@
   <description value="HL7 Reserved Identifier Scheme (RUID)\nA globally unique string defined exclusively by HL7. Identifiers in this scheme are only defined by balloted HL7 specifications. Local communities or systems must never use such reserved identifiers based on bilateral negotiations.\n\nHL7 reserved identifiers are strings that consist only of (US-ASCII) letters, digits and hyphens, where the first character must be a letter. HL7 may assign these reserved identifiers as mnemonic identifiers for major concepts of interest to HL7."/>
   <kind value="primitive-type"/>
   <abstract value="false"/>
-  <type value="id"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/id"/>
+  <type value="string"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/string"/>
   <derivation value="constraint"/> 
   <differential>
-    <element id="id.id">
-      <path value="id.id"/>
+    <element id="string.id">
+      <path value="string.id"/>
       <min value="0"/>
     </element>
-    <element id="id.extension">
-      <path value="id.extension"/>
+    <element id="string.extension">
+      <path value="string.extension"/>
       <min value="0"/>
     </element>
-    <element id="id.value">
-      <path value="id.value"/>
+    <element id="string.value">
+      <path value="string.value"/>
       <representation value="xmlAttr"/>
       <constraint>
         <key value="ruid-value"/>

--- a/input/resources/st-simple.xml
+++ b/input/resources/st-simple.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="st-simple"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'st'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/st-simple"/>
+  <name value="st"/>
+  <title value="st: Character String"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="The character string data type stands for text data, primarily intended for machine processing (e.g. sorting, querying, indexing, etc.) Used for names, symbols, and formal expressions."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="string"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/string"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="string.id">
+      <path value="string.id"/>
+      <max value="0"/>
+    </element>
+    <element id="string.extension">
+      <path value="string.extension"/>
+      <max value="0"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/ts-simple.xml
+++ b/input/resources/ts-simple.xml
@@ -38,7 +38,7 @@
         <key value="ts-value"/>
         <severity value="error"/>
         <human value="A timestamp may be any portion from YYYY to YYYYMMDDhhmmss. If precise to the second, may include fractional seconds, and an offset of +/-HHMM"/>
-        <expression value="matches('^[0-9]{1,8}|([0-9]{9,14}|[0-9]{14,14}/.[0-9]+)([+-][0-9]{1,4})?$')"/>
+        <expression value="matches('^[0-9]{1,8}|([0-9]{9,14}|[0-9]{14,14}\\.[0-9]+)([+-][0-9]{1,4})?$')"/>
       </constraint>
     </element>
   </differential>

--- a/input/resources/ts-simple.xml
+++ b/input/resources/ts-simple.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ts-simple"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'ts'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/ts-simple"/>
+  <name value="ts"/>
+  <title value="ts: Point in Time"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="A quantity specifying a point on the axis of natural time. A point in time is most often represented as a calendar expression."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="string"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/string"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="string.id">
+      <path value="string.id"/>
+      <max value="0"/>
+    </element>
+    <element id="string.extension">
+      <path value="string.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="string.value">
+      <path value="string.value"/>
+      <representation value="xmlAttr"/>
+      <constraint>
+        <key value="ts-value"/>
+        <severity value="error"/>
+        <human value="A timestamp may be any portion from YYYY to YYYYMMDDhhmmss. If precise to the second, may include fractional seconds, and an offset of +/-HHMM"/>
+        <expression value="matches('^[0-9]{1,8}|([0-9]{9,14}|[0-9]{14,14}/.[0-9]+)([+-][0-9]{1,4})?$')"/>
+      </constraint>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/uid.xml
+++ b/input/resources/uid.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="uid"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'uid'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/uid"/>
+  <name value="uid"/>
+  <title value="uid: Unique Identifier String"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="A unique identifier string is a character string which identifies an object in a globally unique and timeless manner. The allowable formats and values and procedures of this data type are strictly controlled by HL7. At this time, user-assigned identifiers may be certain character representations of ISO Object Identifiers (OID) and DCE Universally Unique Identifiers (UUID). HL7 also reserves the right to assign other forms of UIDs (RUID), such as mnemonic identifiers for code systems."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="string"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/string"/>
+  <derivation value="constraint"/> 
+  <differential>
+    <element id="string.id">
+      <path value="string.id"/>
+      <max value="0"/>
+    </element>
+    <element id="string.extension">
+      <path value="string.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="string.value">
+      <path value="string.value"/>
+      <representation value="xmlAttr"/>
+      <constraint>
+        <key value="uid-value"/>
+        <severity value="error"/>
+        <human value="Must conform to OID (#.#.#), UUID (32 hexadecimal digits separated by hyphens), or RUID (a letter followed by any combination of letters, numbers or hyphens)"/>
+        <expression value="matches('^([0-2](/.(0|[1-9][0-9]*))+)|([0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12})|([A-Za-z][A-Za-z0-9/-]*)$')"/>
+      </constraint>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/uid.xml
+++ b/input/resources/uid.xml
@@ -38,7 +38,7 @@
         <key value="uid-value"/>
         <severity value="error"/>
         <human value="Must conform to OID (#.#.#), UUID (32 hexadecimal digits separated by hyphens), or RUID (a letter followed by any combination of letters, numbers or hyphens)"/>
-        <expression value="matches('^([0-2](/.(0|[1-9][0-9]*))+)|([0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12})|([A-Za-z][A-Za-z0-9/-]*)$')"/>
+        <expression value="matches('^([0-2](\\.(0|[1-9][0-9]*))+)|([0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12})|([A-Za-z][A-Za-z0-9\\-]*)$')"/>
       </constraint>
     </element>
   </differential>

--- a/input/resources/uid.xml
+++ b/input/resources/uid.xml
@@ -19,20 +19,20 @@
   <description value="A unique identifier string is a character string which identifies an object in a globally unique and timeless manner. The allowable formats and values and procedures of this data type are strictly controlled by HL7. At this time, user-assigned identifiers may be certain character representations of ISO Object Identifiers (OID) and DCE Universally Unique Identifiers (UUID). HL7 also reserves the right to assign other forms of UIDs (RUID), such as mnemonic identifiers for code systems."/>
   <kind value="primitive-type"/>
   <abstract value="false"/>
-  <type value="string"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/string"/>
+  <type value="id"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/id"/>
   <derivation value="constraint"/> 
   <differential>
-    <element id="string.id">
-      <path value="string.id"/>
+    <element id="id.id">
+      <path value="id.id"/>
       <max value="0"/>
     </element>
-    <element id="string.extension">
-      <path value="string.extension"/>
+    <element id="id.extension">
+      <path value="id.extension"/>
       <max value="0"/>
     </element>
-    <element id="string.value">
-      <path value="string.value"/>
+    <element id="id.value">
+      <path value="id.value"/>
       <representation value="xmlAttr"/>
       <constraint>
         <key value="uid-value"/>

--- a/input/resources/uid.xml
+++ b/input/resources/uid.xml
@@ -19,20 +19,20 @@
   <description value="A unique identifier string is a character string which identifies an object in a globally unique and timeless manner. The allowable formats and values and procedures of this data type are strictly controlled by HL7. At this time, user-assigned identifiers may be certain character representations of ISO Object Identifiers (OID) and DCE Universally Unique Identifiers (UUID). HL7 also reserves the right to assign other forms of UIDs (RUID), such as mnemonic identifiers for code systems."/>
   <kind value="primitive-type"/>
   <abstract value="false"/>
-  <type value="id"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/id"/>
+  <type value="string"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/string"/>
   <derivation value="constraint"/> 
   <differential>
-    <element id="id.id">
-      <path value="id.id"/>
+    <element id="string.id">
+      <path value="string.id"/>
       <max value="0"/>
     </element>
-    <element id="id.extension">
-      <path value="id.extension"/>
+    <element id="string.extension">
+      <path value="string.extension"/>
       <max value="0"/>
     </element>
-    <element id="id.value">
-      <path value="id.value"/>
+  <element id="string.value">
+      <path value="string.value"/>
       <representation value="xmlAttr"/>
       <constraint>
         <key value="uid-value"/>

--- a/input/resources/url.xml
+++ b/input/resources/url.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="url"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'url'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/url"/>
+  <name value="url"/>
+  <title value="url: Universal Resource Locator"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="A telecommunications address specified according to Internet standard RFC 1738 [http://www.ietf.org/rfc/rfc1738.txt]. The URL specifies the protocol and the contact point defined by that protocol for the resource.  Notable uses of the telecommunication address data type are for telephone and telefax numbers, e-mail addresses, Hypertext references, FTP references, etc."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="url"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/url"/>
+  <derivation value="constraint"/> 
+  <differential>
+    <element id="url.id">
+      <path value="url.id"/>
+      <max value="0"/>
+    </element>
+    <element id="url.extension">
+      <path value="url.extension"/>
+      <max value="0"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/uuid.xml
+++ b/input/resources/uuid.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="uuid"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'uuid'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/uuid"/>
+  <name value="uuid"/>
+  <title value="uuid: DCE Universal Unique Identifier"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="A globally unique string representing a DCE Universal Unique Identifier (UUID) in the common UUID format that consists of 5 hyphen-separated groups of hexadecimal digits having 8, 4, 4, 4, and 12 places respectively.\n\n***NOTE:*** The output of UUID related programs and functions may use all sorts of forms, upper case, lower case, and with or without the hyphens that group the digits. This variate output must be postprocessed to conform to the HL7 specification, i.e., the hyphens must be inserted for the 8-4-4-4-12 grouping and all hexadecimal digits must be converted to upper case."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="id"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/id"/>
+  <derivation value="constraint"/> 
+  <differential>
+    <element id="id.id">
+      <path value="id.id"/>
+      <max value="0"/>
+    </element>
+    <element id="id.extension">
+      <path value="id.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="id.value">
+      <path value="id.value"/>
+      <representation value="xmlAttr"/>
+      <constraint>
+        <key value="uuid-value"/>
+        <severity value="error"/>
+        <human value="Must contain 5 hyphen-separated groups of upper-case hexadecimal digits having 8, 4, 4, 4, and 12 places respectively."/>
+        <expression value="matches('^[0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12}$')"/>
+      </constraint>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/uuid.xml
+++ b/input/resources/uuid.xml
@@ -19,20 +19,20 @@
   <description value="A globally unique string representing a DCE Universal Unique Identifier (UUID) in the common UUID format that consists of 5 hyphen-separated groups of hexadecimal digits having 8, 4, 4, 4, and 12 places respectively.\n\n***NOTE:*** The output of UUID related programs and functions may use all sorts of forms, upper case, lower case, and with or without the hyphens that group the digits. This variate output must be postprocessed to conform to the HL7 specification, i.e., the hyphens must be inserted for the 8-4-4-4-12 grouping and all hexadecimal digits must be converted to upper case."/>
   <kind value="primitive-type"/>
   <abstract value="false"/>
-  <type value="id"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/id"/>
+  <type value="string"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/string"/>
   <derivation value="constraint"/> 
   <differential>
-    <element id="id.id">
-      <path value="id.id"/>
+    <element id="string.id">
+      <path value="string.id"/>
       <max value="0"/>
     </element>
-    <element id="id.extension">
-      <path value="id.extension"/>
+    <element id="string.extension">
+      <path value="string.extension"/>
       <max value="0"/>
     </element>
-    <element id="id.value">
-      <path value="id.value"/>
+    <element id="string.value">
+      <path value="string.value"/>
       <representation value="xmlAttr"/>
       <constraint>
         <key value="uuid-value"/>

--- a/input/resources/xs:ID.xml
+++ b/input/resources/xs:ID.xml
@@ -39,7 +39,7 @@
         <key value="uid-value"/>
         <severity value="error"/>
         <human value="Must match the format specified by XML Schema's definition for ID"/>
-        <expression value="matches('^[/i-[:]][/c-[:]]*$')"/>
+        <expression value="matches('^[\\i-[:]][\\c-[:]]*$')"/>
       </constraint>
     </element>
   </differential>

--- a/input/resources/xs:ID.xml
+++ b/input/resources/xs:ID.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="xs-ID"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>Primitive type 'xs:ID'</p>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+    <!-- Though the ID's type is in namespace http://www.w3.org/2001/XMLSchema, the ID itself remains in v3 -->
+    <valueUri value="urn:hl7-org:v3"/>
+  </extension>
+  <url value="http://hl7.org/cda/stds/core/StructureDefinition/xs-ID"/>
+  <name value="xs:ID"/>
+  <title value="xs:ID "/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <publisher value="HL7"/>
+  <description value="ID represents the ID attribute type from [XML 1.0 (Second Edition)]. The &quot;value space&quot; of ID is the set of all strings that &quot;match&quot; the NCName production in [Namespaces in XML]. The &quot;lexical space&quot; of ID is the set of all strings that &quot;match&quot; the NCName production in [Namespaces in XML]."/>
+  <kind value="primitive-type"/>
+  <abstract value="false"/>
+  <type value="id"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/id"/>
+  <derivation value="constraint"/> 
+  <differential>
+    <element id="id.id">
+      <path value="id.id"/>
+      <max value="0"/>
+    </element>
+    <element id="id.extension">
+      <path value="id.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="id.value">
+      <path value="id.value"/>
+      <representation value="xmlAttr"/>
+      <constraint>
+        <key value="uid-value"/>
+        <severity value="error"/>
+        <human value="Must match the format specified by XML Schema's definition for ID"/>
+        <expression value="matches('^[/i-[:]][/c-[:]]*$')"/>
+      </constraint>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/xs:ID.xml
+++ b/input/resources/xs:ID.xml
@@ -13,7 +13,7 @@
   </extension>
   <url value="http://hl7.org/cda/stds/core/StructureDefinition/xs-ID"/>
   <name value="xs:ID"/>
-  <title value="xs:ID "/>
+  <title value="xs:ID"/>
   <status value="active"/>
   <experimental value="false"/>
   <publisher value="HL7"/>


### PR DESCRIPTION
And a number of other clean-ups; but mostly updating every place that used a FHIR primitive type to use a new CDA primitive type.

When clashes existed (like cs vs CS), I named the file `-simple` rather than `-prim` since that's how they were defined in XML schema. I'm not married to that name, but also didn't want to prefix or postfix every primitive/simple with something.

Also added groupings, so these (and regular Data Types) show up more cleanly in the TOC and Artifact index.