### PR TITLE
Hyphen vs underscore

### DIFF
--- a/CDA-core.xml
+++ b/CDA-core.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ciUrl="https://build.fhir.org/ig/HL7/CDA-core-2.0" defaultVersion="current" defaultWorkgroup="" url="http://hl7.org/cda/stds/core">
 <version code="current" url="https://build.fhir.org/ig/HL7/CDA-core-2.0"/>
-<version code="2.0.0" url="http://hl7.org/cda/stds/core/"/>
 <version code="2.1.0-draft1" url="http://hl7.org/cda/stds/core/draft1"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
@@ -79,7 +78,7 @@
 <artifact id="StructureDefinition/Organization" key="StructureDefinition-Organization" name="Organization (CDA Class)"/>
 <artifact id="StructureDefinition/OrganizationPartOf" key="StructureDefinition-OrganizationPartOf" name="OrganizationPartOf (CDA Class)"/>
 <artifact id="StructureDefinition/Organizer" key="StructureDefinition-Organizer" name="Organizer (CDA Class)"/>
-<artifact id="StructureDefinition/PIVL-TS" key="StructureDefinition-PIVL-TS" name="PIVL-TS: PeriodicIntervalOfTime (V3 Data Type)"/>
+<artifact id="StructureDefinition/PIVL-TS" key="StructureDefinition-PIVL-TS" name="PIVL_TS: PeriodicIntervalOfTime (V3 Data Type)"/>
 <artifact id="StructureDefinition/PN" key="StructureDefinition-PN" name="PN: PersonName (V3 Data Type)"/>
 <artifact id="StructureDefinition/PQ" key="StructureDefinition-PQ" name="PQ: PhysicalQuantity (V3 Data Type)"/>
 <artifact id="StructureDefinition/PQR" key="StructureDefinition-PQR" name="PQR: PhysicalQuantityRepresentation (V3 Data Type)"/>
@@ -98,7 +97,7 @@
 <artifact id="StructureDefinition/Procedure" key="StructureDefinition-Procedure" name="Procedure (CDA Class)"/>
 <artifact id="StructureDefinition/QTY" key="StructureDefinition-QTY" name="QTY: Quantity (V3 Data Type)"/>
 <artifact id="StructureDefinition/REAL" key="StructureDefinition-REAL" name="REAL: RealNumber (V3 Data Type)"/>
-<artifact id="StructureDefinition/RTO-PQ-PQ" key="StructureDefinition-RTO-PQ-PQ" name="RTO-PQ-PQ: Ratio (V3 Data Type)"/>
+<artifact id="StructureDefinition/RTO-PQ-PQ" key="StructureDefinition-RTO-PQ-PQ" name="RTO_PQ_PQ: Ratio (V3 Data Type)"/>
 <artifact id="StructureDefinition/RecordTarget" key="StructureDefinition-RecordTarget" name="RecordTarget (CDA Class)"/>
 <artifact id="StructureDefinition/RegionOfInterest" key="StructureDefinition-RegionOfInterest" name="RegionOfInterest (CDA Class)"/>
 <artifact id="StructureDefinition/RelatedDocument" key="StructureDefinition-RelatedDocument" name="RelatedDocument (CDA Class)"/>
@@ -106,8 +105,8 @@
 <artifact id="StructureDefinition/RelatedSubject" key="StructureDefinition-RelatedSubject" name="RelatedSubject (CDA Class)"/>
 <artifact id="StructureDefinition/SC" key="StructureDefinition-SC" name="SC: CharacterStringWithCode (V3 Data Type)"/>
 <artifact id="StructureDefinition/ST" key="StructureDefinition-ST" name="ST: CharacterString (V3 Data Type)"/>
-<artifact id="StructureDefinition/SXCM-TS" key="StructureDefinition-SXCM-TS" name="SXCM-TS: GeneralTimingSpecification (V3 Data Type)"/>
-<artifact id="StructureDefinition/SXPR-TS" key="StructureDefinition-SXPR-TS" name="SXPR-TS: Component part of GTS (V3 Data Type)"/>
+<artifact id="StructureDefinition/SXCM-TS" key="StructureDefinition-SXCM-TS" name="SXCM_TS: GeneralTimingSpecification (V3 Data Type)"/>
+<artifact id="StructureDefinition/SXPR-TS" key="StructureDefinition-SXPR-TS" name="SXPR_TS: Component part of GTS (V3 Data Type)"/>
 <artifact id="StructureDefinition/Section" key="StructureDefinition-Section" name="Section (CDA Class)"/>
 <artifact id="StructureDefinition/ServiceEvent" key="StructureDefinition-ServiceEvent" name="ServiceEvent (CDA Class)"/>
 <artifact id="StructureDefinition/Specimen" key="StructureDefinition-Specimen" name="Specimen (CDA Class)"/>

--- a/input/examples/clinicaldocument-example.xml
+++ b/input/examples/clinicaldocument-example.xml
@@ -1,0 +1,1095 @@
+<?xml version="1.0"?>
+<!-- Sample document provided with original CDA specification -->
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<!-- 
+********************************************************
+  CDA Header
+********************************************************
+-->
+	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+	<templateId root="2.16.840.1.113883.3.27.1776"/>
+	<id extension="c266" root="2.16.840.1.113883.19.4"/>
+	<code code="11488-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Consultation note"/>
+	<title>Good Health Clinic Consultation Note</title>
+	<effectiveTime value="20000407"/>
+	<confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+	<languageCode code="en-US"/>
+	<setId extension="BB35" root="2.16.840.1.113883.19.7"/>
+	<versionNumber value="2"/>
+	<recordTarget>
+		<patientRole>
+			<id extension="12345" root="2.16.840.1.113883.19.5"/>
+			<patient>
+			<name>
+					<given>Henry</given>
+					<family>Levin</family>
+					<suffix>the 7th</suffix>
+				</name>
+				<administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"/>
+				<birthTime value="19320924"/>
+			</patient>
+			<providerOrganization>
+				<id root="2.16.840.1.113883.19.5"/>
+			</providerOrganization>
+		</patientRole>
+	</recordTarget>
+	<author>
+		<time value="2000040714"/>
+		<assignedAuthor>
+			<id extension="KP00017" root="2.16.840.1.113883.19.5"/>
+			<assignedPerson>
+				<name>
+					<given>Robert</given>
+					<family>Dolin</family>
+					<suffix>MD</suffix>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5"/>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	<custodian>
+		<assignedCustodian>
+			<representedCustodianOrganization>
+				<id root="2.16.840.1.113883.19.5"/>
+				<name>Good Health Clinic</name>
+			</representedCustodianOrganization>
+		</assignedCustodian>
+	</custodian>
+	<legalAuthenticator>
+		<time value="20000408"/>
+		<signatureCode code="S"/>
+		<assignedEntity>
+			<id extension="KP00017" root="2.16.840.1.113883.19.5"/>
+			<assignedPerson>
+				<name>
+					<given>Robert</given>
+					<family>Dolin</family>
+					<suffix>MD</suffix>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="2.16.840.1.113883.19.5"/>
+			</representedOrganization>
+		</assignedEntity>
+	</legalAuthenticator>
+	<relatedDocument typeCode="RPLC">
+		<parentDocument>
+			<id extension="a123" root="2.16.840.1.113883.19.4"/>
+			<setId extension="BB35" root="2.16.840.1.113883.19.7"/>
+			<versionNumber value="1"/>
+		</parentDocument>
+	</relatedDocument>
+	<componentOf>
+		<encompassingEncounter>
+			<id extension="KPENC1332" root="2.16.840.1.113883.19.6"/>
+			<effectiveTime value="20000407"/>
+			<encounterParticipant typeCode="CON">
+				<time value="20000407"/>
+				<assignedEntity>
+					<id extension="KP00017" root="2.16.840.1.113883.19.5"/>
+					<assignedPerson>
+						<name>
+							<given>Robert</given>
+							<family>Dolin</family>
+							<suffix>MD</suffix>
+						</name>
+					</assignedPerson>
+					<representedOrganization>
+						<id root="2.16.840.1.113883.19.5"/>
+					</representedOrganization>
+				</assignedEntity>
+			</encounterParticipant>
+			<location>
+				<healthCareFacility classCode="DSDLOC">
+					<code code="GIM" codeSystem="2.16.840.1.113883.5.10588" displayName="General internal medicine clinic"/>
+				</healthCareFacility>
+			</location>
+		</encompassingEncounter>
+	</componentOf>
+	<!-- 
+********************************************************
+  CDA Body
+********************************************************
+-->
+	<component>
+		<structuredBody>
+			<!-- 
+********************************************************
+  History of Present Illness section
+********************************************************
+-->
+			<component>
+				<section>
+					<code code="10164-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>History of Present Illness</title>
+					<text>
+						<content styleCode="Bold">Henry Levin, the 7<sup>th</sup>
+						</content> is a 67 year old male referred for further asthma management. Onset of asthma in his <content revised="delete">twenties</content>
+						<content revised="insert">teens</content>. He was hospitalized twice last year, and already twice this year. He has not been able to be weaned off steroids for the past several months. 
+						</text>
+				</section>
+			</component>
+			<!-- 
+********************************************************
+  Past Medical History section
+********************************************************
+-->
+			<component>
+				<section>
+					<code code="10153-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Past Medical History</title>
+					<text>
+						<list>
+							<item>
+								<content ID="a1">Asthma</content>
+							</item>
+							<item>
+								<content ID="a2">Hypertension (see HTN.cda for details)</content>
+							</item>
+							<item>
+								<content ID="a3">Osteoarthritis, 
+									<content ID="a4">right knee</content>
+								</content>
+							</item>
+						</list>
+					</text>
+					<entry>
+						<observation classCode="COND" moodCode="EVN">
+							<code code="195967001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Asthma">
+								<originalText>
+									<reference value="#a1"/>
+								</originalText>
+							</code>
+							<statusCode code="completed"/>
+							<effectiveTime value="1950"/>
+							<reference typeCode="XCRPT">
+								<externalObservation>
+									<id root="2.16.840.1.113883.19.1.2765"/>
+								</externalObservation>
+							</reference>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="COND" moodCode="EVN">
+							<code code="59621000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="HTN">
+								<originalText>
+									<reference value="#a2"/>
+								</originalText>
+							</code>
+							<statusCode code="completed"/>
+							<reference typeCode="SPRT">
+								<seperatableInd value="false"/>
+								<externalDocument>
+									<id root="2.16.840.1.113883.19.4.789"/>
+									<text mediaType="multipart/related">
+										<reference value="HTN.cda"/>
+									</text>
+									<setId root="2.16.840.1.113883.19.7.2465"/>
+									<versionNumber value="1"/>
+								</externalDocument>
+							</reference>
+							<reference typeCode="XCRPT">
+								<externalObservation>
+									<id root="2.16.840.1.113883.19.1.2005"/>
+								</externalObservation>
+							</reference>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="COND" moodCode="EVN">
+							<code xsi:type="CD" code="396275006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Osteoarthritis">
+								<originalText>
+									<reference value="#a3"/>
+								</originalText>
+							</code>
+							<statusCode code="completed"/>
+							<targetSiteCode code="49076000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Knee joint">
+								<originalText>
+									<reference value="#a4"/>
+								</originalText>
+								<qualifier>
+									<name code="78615007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="with laterality"/>
+									<value code="24028007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="right"/>
+								</qualifier>
+							</targetSiteCode>
+							<reference typeCode="XCRPT">
+								<externalObservation>
+									<id root="2.16.840.1.113883.19.1.1805"/>
+								</externalObservation>
+							</reference>
+						</observation>
+					</entry>
+				</section>
+			</component>
+			<!-- 
+********************************************************
+  Medications section
+********************************************************
+-->
+			<component>
+				<section>
+					<code code="10160-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Medications</title>
+					<text>
+						<list>
+							<item>Theodur 200mg BID</item>
+							<item>Proventil inhaler 2puffs QID PRN</item>
+							<item>Prednisone 20mg qd</item>
+							<item>HCTZ 25mg qd</item>
+						</list>
+					</text>
+					<entry>
+						<substanceAdministration classCode="SBADM" moodCode="EVN">
+							<text>Theodur 200mg BID</text>
+							<effectiveTime xsi:type="PIVL_TS" institutionSpecified="true">
+								<period value="12" unit="h"/>
+							</effectiveTime>
+							<routeCode code="PO" codeSystem="2.16.840.1.113883.5.112" codeSystemName="RouteOfAdministration"/>
+							<doseQuantity value="200" unit="mg"/>
+							<consumable>
+								<manufacturedProduct>
+									<manufacturedLabeledDrug>
+										<code code="66493003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Theophylline"/>
+									</manufacturedLabeledDrug>
+								</manufacturedProduct>
+							</consumable>
+						</substanceAdministration>
+					</entry>
+					<entry>
+						<substanceAdministration classCode="SBADM" moodCode="EVN">
+							<text>Proventil inhaler 2puffs QID PRN</text>
+							<effectiveTime xsi:type="PIVL_TS" institutionSpecified="true">
+								<period value="6" unit="h"/>
+							</effectiveTime>
+							<priorityCode code="PRN"/>
+							<routeCode code="IPINHL" codeSystem="2.16.840.1.113883.5.112" codeSystemName="RouteOfAdministration" displayName="Inhalation, oral"/>
+							<doseQuantity value="2"/>
+							<consumable>
+								<manufacturedProduct>
+									<manufacturedLabeledDrug>
+										<code code="91143003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Albuterol"/>
+									</manufacturedLabeledDrug>
+								</manufacturedProduct>
+							</consumable>
+						</substanceAdministration>
+					</entry>
+					<entry>
+						<substanceAdministration classCode="SBADM" moodCode="EVN">
+							<id root="2.16.840.1.113883.19.8.1"/>
+							<text>Prednisone 20mg qd</text>
+							<effectiveTime xsi:type="PIVL_TS" institutionSpecified="true">
+								<period value="24" unit="h"/>
+							</effectiveTime>
+							<routeCode code="PO" codeSystem="2.16.840.1.113883.5.112" codeSystemName="RouteOfAdministration"/>
+							<doseQuantity value="20" unit="mg"/>
+							<consumable>
+								<manufacturedProduct>
+									<manufacturedLabeledDrug>
+										<code code="10312003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Prednisone preparation"/>
+									</manufacturedLabeledDrug>
+								</manufacturedProduct>
+							</consumable>
+						</substanceAdministration>
+					</entry>
+					<entry>
+						<substanceAdministration classCode="SBADM" moodCode="EVN">
+							<text>HCTZ 25mg qd</text>
+							<effectiveTime xsi:type="PIVL_TS" institutionSpecified="true">
+								<period value="24" unit="h"/>
+							</effectiveTime>
+							<routeCode code="PO" codeSystem="2.16.840.1.113883.5.112" codeSystemName="RouteOfAdministration"/>
+							<consumable>
+								<manufacturedProduct>
+									<manufacturedLabeledDrug>
+										<code code="376209006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Hydrochlorothiazide 25mg tablet"/>
+									</manufacturedLabeledDrug>
+								</manufacturedProduct>
+							</consumable>
+						</substanceAdministration>
+					</entry>
+				</section>
+			</component>
+			<!-- 
+********************************************************
+  Allergies & Adverse Reactions section
+********************************************************
+-->
+			<component>
+				<section>
+					<code code="10155-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Allergies and Adverse Reactions</title>
+					<text>
+						<list>
+							<item>Penicillin - Hives</item>
+							<item>Aspirin - Wheezing</item>
+							<item>Codeine - Itching and nausea</item>
+						</list>
+					</text>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<code xsi:type="CD" code="247472004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Hives"/>
+							<statusCode code="completed"/>
+							<entryRelationship typeCode="MFST">
+								<observation classCode="OBS" moodCode="EVN">
+									<code xsi:type="CD" code="91936005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Allergy to penicillin"/>
+									<statusCode code="completed"/>
+								</observation>
+							</entryRelationship>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<code code="56018004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Wheezing"/>
+							<statusCode code="completed"/>
+							<entryRelationship typeCode="MFST">
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="293586001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Allergy to aspirin"/>
+									<statusCode code="completed"/>
+								</observation>
+							</entryRelationship>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<code code="32738000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Pruritis"/>
+							<statusCode code="completed"/>
+							<entryRelationship typeCode="MFST">
+								<observation classCode="OBS" moodCode="EVN">
+									<id root="2.16.840.1.113883.19.1.2010"/>
+									<code code="62014003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Adverse reaction to drug">
+										<qualifier>
+											<name code="246075003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="causative agent"/>
+											<value code="1476002" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="codeine"/>
+										</qualifier>
+									</code>
+									<statusCode code="completed"/>
+								</observation>
+							</entryRelationship>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<code code="73879007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Nausea"/>
+							<statusCode code="completed"/>
+							<entryRelationship typeCode="MFST">
+								<observation classCode="OBS" moodCode="EVN">
+									<id root="2.16.840.1.113883.19.1.2010"/>
+									<code code="84100007" codeSystem="2.16.840.1.113883.6.96"/>
+								</observation>
+							</entryRelationship>
+						</observation>
+					</entry>
+				</section>
+			</component>
+			<!-- 
+********************************************************
+  Family History section
+********************************************************
+-->
+			<component>
+				<section>
+					<code code="10157-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Family history</title>
+					<text>
+						<list>
+							<item>Father had fatal MI in his early 50's.</item>
+							<item>No cancer or diabetes.</item>
+						</list>
+					</text>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<code code="22298006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="MI"/>
+							<statusCode code="completed"/>
+							<effectiveTime value="1970"/>
+							<subject>
+								<relatedSubject classCode="PRS">
+									<code code="FTH" codeSystem="2.16.840.1.113883.5.111"/>
+								</relatedSubject>
+							</subject>
+							<entryRelationship typeCode="CAUS">
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="399347008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="death"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="1970"/>
+								</observation>
+							</entryRelationship>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN" negationInd="true">
+							<code code="275937001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Family history of cancer"/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<high value="20000407" inclusive="true"/>
+							</effectiveTime>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<code code="160274005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="No family history of diabetes"/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<high value="20000407" inclusive="true"/>
+							</effectiveTime>
+						</observation>
+					</entry>
+				</section>
+			</component>
+			<!-- 
+********************************************************
+  Social History section
+********************************************************
+-->
+			<component>
+				<section>
+					<code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Social History</title>
+					<text>
+						<list>
+							<item>Smoking :: 1 PPD between the ages of 20 and 55, and then he quit.</item>
+							<item>Alcohol :: rare</item>
+						</list>
+					</text>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<code code="266924008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="ex-heavy cigarette smoker (20-39/day)"/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<low value="1955"/>
+								<high value="1990"/>
+							</effectiveTime>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<code code="160625004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Date ceased smoking"/>
+							<statusCode code="completed"/>
+							<value xsi:type="TS" value="1990"/>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<code code="266917007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Trivial drinker -  less than 1/day"/>
+							<statusCode code="completed"/>
+						</observation>
+					</entry>
+				</section>
+			</component>
+			<!-- 
+********************************************************
+  Physical Exam section
+********************************************************
+-->
+			<component>
+				<section>
+					<code code="11384-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Physical Examination</title>
+					<!-- 
+          ********************************************************
+            Physical Exam  - Vital Signs
+          ********************************************************
+          -->
+					<component>
+						<section>
+							<code code="8716-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<title>Vital Signs</title>
+							<text>
+								<table>
+									<tbody>
+										<tr>
+											<th>Date / Time</th>
+											<th>April 7, 2000 14:30</th>
+											<th>April 7, 2000 15:30</th>
+										</tr>
+										<tr>
+											<th>Height</th>
+											<td>177 cm (69.7 in)</td>
+										</tr>
+										<tr>
+											<th>Weight</th>
+											<td>194.0 lbs (88.0 kg)</td>
+										</tr>
+										<tr>
+											<th>BMI</th>
+											<td>28.1 kg/m2</td>
+										</tr>
+										<tr>
+											<th>BSA</th>
+											<td>2.05 m2</td>
+										</tr>
+										<tr>
+											<th>Temperature</th>
+											<td>36.9 C (98.5 F)</td>
+											<td>36.9 C (98.5 F)</td>
+										</tr>
+										<tr>
+											<th>Pulse</th>
+											<td>86 / minute</td>
+											<td>84 / minute</td>
+										</tr>
+										<tr>
+											<th>Rhythm</th>
+											<td>Regular</td>
+											<td>Regular</td>
+										</tr>
+										<tr>
+											<th>Respirations</th>
+											<td>16 / minute, unlabored</td>
+											<td>14 / minute</td>
+										</tr>
+										<tr>
+											<th>Systolic</th>
+											<td>132 mmHg</td>
+											<td>135 mmHg</td>
+										</tr>
+										<tr>
+											<th>Diastolic</th>
+											<td>86 mmHg</td>
+											<td>88 mmHg</td>
+										</tr>
+										<tr>
+											<th>Position / Cuff</th>
+											<td>Left Arm</td>
+											<td>Left Arm</td>
+										</tr>
+									</tbody>
+								</table>
+							</text>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="50373000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Body height measure"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071430"/>
+									<value xsi:type="PQ" value="1.77" unit="m">
+										<translation value="69.7" code="[in_I]" codeSystem="2.16.840.1.113883.6.8" codeSystemName="UCUM"/>
+									</value>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="363808001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Body weight measure"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071430"/>
+									<value xsi:type="PQ" value="194.0" unit="[lb_ap]">
+										<translation value="88.0" code="kg" codeSystem="2.16.840.1.113883.6.8" codeSystemName="UCUM"/>
+									</value>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="60621009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Body mass index"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071430"/>
+									<value xsi:type="RTO_PQ_PQ">
+										<numerator value="28.1" unit="kg"/>
+										<denominator value="1" unit="ar"/>
+									</value>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="301898006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Body surface area"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071430"/>
+									<value xsi:type="PQ" value="2.05" unit="ar"/>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="386725007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Body temperature"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071430"/>
+									<value xsi:type="PQ" value="36.9" unit="Cel">
+										<translation value="98.5" code="[degF]" codeSystem="2.16.840.1.113883.6.8" codeSystemName="UCUM"/>
+									</value>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="364075005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Heart rate"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071430"/>
+									<value xsi:type="RTO_PQ_PQ">
+										<numerator value="86"/>
+										<denominator value="1" unit="min"/>
+									</value>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="364075005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Heart rate"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071530"/>
+									<value xsi:type="RTO_PQ_PQ">
+										<numerator value="84"/>
+										<denominator value="1" unit="min"/>
+									</value>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="364074009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Regularity of heart rhythm"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071430"/>
+									<value xsi:type="CD" code="248649006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Heart regular"/>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="364074009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Regularity of heart rhythm"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071530"/>
+									<value xsi:type="CD" code="248649006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Heart regular"/>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="86290005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Respiratory rate"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071430"/>
+									<value xsi:type="RTO_PQ_PQ">
+										<numerator value="16"/>
+										<denominator value="1" unit="min"/>
+									</value>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="276362002" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Breathing easily"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071430"/>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="86290005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Respiratory rate"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071530"/>
+									<value xsi:type="RTO_PQ_PQ">
+										<numerator value="14"/>
+										<denominator value="1" unit="min"/>
+									</value>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="251076008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Cuff blood pressure"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071430"/>
+									<targetSiteCode code="368208006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Left arm"/>
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<code code="271649006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Systolic BP"/>
+											<statusCode code="completed"/>
+											<effectiveTime value="200004071530"/>
+											<value xsi:type="PQ" value="132" unit="mm[Hg]"/>
+										</observation>
+									</entryRelationship>
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<code code="271650006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Diastolic BP"/>
+											<statusCode code="completed"/>
+											<effectiveTime value="200004071530"/>
+											<value xsi:type="PQ" value="86" unit="mm[Hg]"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="251076008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Cuff blood pressure"/>
+									<statusCode code="completed"/>
+									<effectiveTime value="200004071530"/>
+									<targetSiteCode code="368208006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Left arm"/>
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<code code="271649006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Systolic BP"/>
+											<statusCode code="completed"/>
+											<effectiveTime value="200004071530"/>
+											<value xsi:type="PQ" value="135" unit="mm[Hg]"/>
+										</observation>
+									</entryRelationship>
+									<entryRelationship typeCode="COMP">
+										<observation classCode="OBS" moodCode="EVN">
+											<code code="271650006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Diastolic BP"/>
+											<statusCode code="completed"/>
+											<effectiveTime value="200004071530"/>
+											<value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+										</observation>
+									</entryRelationship>
+								</observation>
+							</entry>
+						</section>
+					</component>
+					<!-- 
+          ********************************************************
+            Physical Exam  - Skin
+          ********************************************************
+          -->
+					<component>
+						<section>
+							<code code="8709-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<title>Skin Exam</title>
+							<text>Erythematous rash, palmar surface, left index finger.
+								 <renderMultiMedia referencedObject="MM1"/>
+							</text>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="271807003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Rash"/>
+									<statusCode code="completed"/>
+									<methodCode code="32750006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Inspection"/>
+									<targetSiteCode code="48856004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Skin of palmer surface of index finger">
+										<qualifier>
+											<name code="78615007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="with laterality"/>
+											<value code="7771000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="left"/>
+										</qualifier>
+									</targetSiteCode>
+									<entryRelationship typeCode="SPRT">
+										<regionOfInterest classCode="ROIOVL" moodCode="EVN" ID="MM1">
+											<id root="2.16.840.1.113883.19.3.1"/>
+											<code code="ELLIPSE"/>
+											<value value="3"/>
+											<value value="1"/>
+											<value value="3"/>
+											<value value="7"/>
+											<value value="2"/>
+											<value value="4"/>
+											<value value="4"/>
+											<value value="4"/>
+											<entryRelationship typeCode="SUBJ">
+												<observationMedia classCode="OBS" moodCode="EVN">
+													<id root="2.16.840.1.113883.19.2.1"/>
+													<value mediaType="image/gif">
+														<reference value="lefthand.gif"/>
+													</value>
+												</observationMedia>
+											</entryRelationship>
+										</regionOfInterest>
+									</entryRelationship>
+								</observation>
+							</entry>
+						</section>
+					</component>
+					<!-- 
+          ********************************************************
+            Physical Exam  - Lungs
+          ********************************************************
+          -->
+					<component>
+						<section>
+							<code code="8710-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<title>Lungs</title>
+							<text>Clear with no wheeze. Good air flow.</text>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="48348007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Chest clear"/>
+									<statusCode code="completed"/>
+									<methodCode code="37931006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Auscultation"/>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN" negationInd="true">
+									<code code="56018004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Wheezing"/>
+									<statusCode code="completed"/>
+									<methodCode code="37931006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Auscultation"/>
+								</observation>
+							</entry>
+						</section>
+					</component>
+					<!-- 
+          ********************************************************
+            Physical Exam  - Cardiac
+          ********************************************************
+          -->
+					<component>
+						<section>
+							<code code="10223-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<title>Cardiac</title>
+							<text>RRR with no murmur, no S3, no S4.</text>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="76863003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Normal heart rate"/>
+									<statusCode code="completed"/>
+									<methodCode code="37931006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Auscultation"/>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN" negationInd="true">
+									<code code="88610006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="heart murmur"/>
+									<statusCode code="completed"/>
+									<methodCode code="37931006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Auscultation"/>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN" negationInd="true">
+									<code code="277455002" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Third heart sound"/>
+									<statusCode code="completed"/>
+									<methodCode code="37931006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Auscultation"/>
+								</observation>
+							</entry>
+							<entry>
+								<observation classCode="OBS" moodCode="EVN">
+									<code code="60721002" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Fourth heart sound inaudible"/>
+									<statusCode code="completed"/>
+									<methodCode code="37931006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Auscultation"/>
+								</observation>
+							</entry>
+						</section>
+					</component>
+				</section>
+			</component>
+			<!-- 
+********************************************************
+  Labs section
+********************************************************
+-->
+			<component>
+				<section>
+					<code code="11502-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Labs</title>
+					<text>
+						<list>
+							<item>CXR 02/03/1999: Hyperinflated. Normal cardiac silhouette, clear lungs.</item>					
+							<item>Peak Flow today: 260 l/m</item>
+						</list>
+					</text>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<code code="282290005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Imaging interpretation"/>
+							<statusCode code="completed"/>
+							<entryRelationship typeCode="COMP">
+								<observation classCode="OBS" moodCode="EVN">
+									<id root="2.16.840.1.113883.19.1.3005"/>
+									<code code="249674001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Chest hyperinflated"/>
+								</observation>
+							</entryRelationship>
+							<entryRelationship typeCode="COMP">
+								<observation classCode="OBS" moodCode="EVN">
+									<id root="2.16.840.1.113883.19.1.5505"/>
+									<code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" nullFlavor="OTH">
+										<originalText>normal cardiac silhouette</originalText>
+									</code>
+								</observation>
+							</entryRelationship>
+							<entryRelationship typeCode="COMP">
+								<observation classCode="OBS" moodCode="EVN" negationInd="true">
+									<id root="2.16.840.1.113883.19.1.6675"/>
+									<code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" nullFlavor="OTH">
+										<originalText>radiopacities</originalText>
+									</code>
+								</observation>
+							</entryRelationship>
+							<reference typeCode="SPRT">
+								<externalObservation classCode="DGIMG">
+									<id root="2.16.840.1.113883.19.1.14"/>
+									<code code="56350004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Chest-X-ray"/>
+								</externalObservation>
+							</reference>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<id root="2.16.840.1.113883.19.1.7005"/>
+							<code code="313193002" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Peak flow"/>
+							<statusCode code="completed"/>
+							<effectiveTime value="20000407"/>
+							<value xsi:type="RTO_PQ_PQ">
+								<numerator value="260" unit="l"/>
+								<denominator value="1" unit="min"/>
+							</value>
+						</observation>
+					</entry>
+				</section>
+			</component>
+			<!-- 
+********************************************************
+  In-office Procedure section
+********************************************************
+-->
+			<component>
+				<section>
+					<code code="29554-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>In-office Procedures</title>
+					<text>
+						<list>
+							<item>Suture removal, left forearm.</item>
+						</list>
+					</text>
+					<entry>
+						<procedure classCode="PROC" moodCode="EVN">
+							<code code="30549001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Suture removal"/>
+							<statusCode code="completed"/>
+							<effectiveTime value="200004071430"/>
+							<targetSiteCode code="66480008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Left forearm"/>
+						</procedure>
+					</entry>
+				</section>
+			</component>
+			<!-- 
+********************************************************
+  Assessment section
+********************************************************
+-->
+			<component>
+				<section>
+					<code code="11496-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Assessment</title>
+					<text>
+						<list>
+							<item>Asthma, with prior smoking history. Difficulty weaning off steroids. Will try gradual taper.</item>
+							<item>Hypertension, well-controlled.</item>
+							<item>Contact dermatitis on finger.</item>
+						</list>
+					</text>
+					<entry>
+						<observation classCode="COND" moodCode="EVN">
+							<code code="14657009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Established diagnosis"/>
+							<statusCode code="completed"/>
+							<effectiveTime value="200004071530"/>
+							<value xsi:type="CD" code="195967001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Asthma">
+								<translation code="49390" codeSystem="2.16.840.1.113883.6.2" codeSystemName="ICD9CM" displayName="ASTHMA W/O STATUS ASTHMATICUS"/>
+							</value>
+							<reference typeCode="ELNK">
+								<externalObservation classCode="COND">
+									<id root="2.16.840.1.113883.19.1.35"/>
+								</externalObservation>
+							</reference>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="COND" moodCode="EVN">
+							<code code="14657009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Established diagnosis"/>
+							<statusCode code="completed"/>
+							<effectiveTime value="200004071530"/>
+							<value xsi:type="CD" code="59621000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Essential hypertension">
+								<translation code="4019" codeSystem="2.16.840.1.113883.6.2" codeSystemName="ICD9CM" displayName="HYPERTENSION NOS"/>
+							</value>
+							<reference typeCode="ELNK">
+								<externalObservation classCode="COND">
+									<id root="2.16.840.1.113883.19.1.37"/>
+								</externalObservation>
+							</reference>
+						</observation>
+					</entry>
+					<entry>
+						<observation classCode="COND" moodCode="EVN">
+							<code code="14657009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Established diagnosis"/>
+							<statusCode code="completed"/>
+							<effectiveTime value="200004071530"/>
+							<value xsi:type="CD" code="40275004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Contact dermatitis">
+								<translation code="692.9" codeSystem="2.16.840.1.113883.6.2" codeSystemName="ICD9CM" displayName="Contact Dermatitis, NOS"/>
+							</value>
+							<targetSiteCode code="48856004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Skin of palmer surface of index finger">
+								<qualifier>
+									<name code="78615007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="with laterality"/>
+									<value code="7771000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="left"/>
+								</qualifier>
+							</targetSiteCode>
+						</observation>
+					</entry>
+				</section>
+			</component>
+			<!-- 
+********************************************************
+  Plan section
+********************************************************
+-->
+			<component>
+				<section>
+					<templateId root="2.16.840.1.113883.3.27.354"/>
+					<code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Plan</title>
+					<text>
+						<list>
+							<item>Complete PFTs with lung volumes.</item>
+							<item>Chem-7 tomorrow.</item>
+							<item>Teach peak flow rate measurement.</item>
+							<item>Decrease prednisone to 20qOD alternating with 18qOD.</item>
+							<item>Hydrocortisone cream to finger BID.</item>
+							<item>RTC 1 week.</item>
+						</list>
+					</text>
+					<entry>
+						<act classCode="ACT" moodCode="INT">
+							<id/>
+							<code code="23426006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Pulmonary function test"/>
+							<text>Complete PFTs with lung volumes.</text>
+							<entryRelationship typeCode="COMP">
+								<act classCode="ACT" moodCode="INT">
+									<code code="252472004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Lung volume test"/>
+								</act>
+							</entryRelationship>
+						</act>
+					</entry>
+					<entry>
+						<observation classCode="OBS" moodCode="INT">
+							<code code="24320-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+								<originalText>Chem-7</originalText>
+								<translation code="aYU7t6" codeSystem="2.16.840.1.113883.19.278.47" codeSystemName="MyLocalCodeSystem" displayName="Chem7"/>
+							</code>
+							<text>Chem-7 tomorrow</text>
+							<effectiveTime value="20000408"/>
+						</observation>
+					</entry>
+					<entry>
+						<act classCode="ACT" moodCode="INT">
+							<id/>
+							<code code="223468009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Teaching of skills">
+								<qualifier>
+									<name code="363702006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="has focus"/>
+									<value code="29893006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Peak flow rate measurement"/>
+								</qualifier>
+							</code>
+						</act>
+					</entry>
+					<entry>
+						<substanceAdministration classCode="SBADM" moodCode="RQO">
+							<text>prednisone 20qOD alternating with 18qOD.</text>
+							<routeCode code="PO" codeSystem="2.16.840.1.113883.5.112" codeSystemName="RouteOfAdministration"/>
+							<consumable>
+								<manufacturedProduct>
+									<manufacturedLabeledDrug>
+										<code code="10312003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Prednisone preparation"/>
+									</manufacturedLabeledDrug>
+								</manufacturedProduct>
+							</consumable>
+						</substanceAdministration>
+					</entry>
+					<entry>
+						<substanceAdministration classCode="SBADM" moodCode="RQO">
+							<text>Hydrocortisone cream to finger BID.</text>
+							<effectiveTime xsi:type="PIVL_TS" institutionSpecified="true">
+								<period value="12" unit="h"/>
+							</effectiveTime>
+							<routeCode code="SKIN" codeSystem="2.16.840.1.113883.5.112" codeSystemName="RouteOfAdministration" displayName="Topical application, skin"/>
+							<approachSiteCode code="48856004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Skin of palmer surface of index finger">
+								<qualifier>
+									<name code="78615007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="with laterality"/>
+									<value code="7771000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="left"/>
+								</qualifier>
+							</approachSiteCode>
+							<consumable>
+								<manufacturedProduct>
+									<manufacturedLabeledDrug>
+										<code code="331646005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Hydrocortisone cream"/>
+									</manufacturedLabeledDrug>
+								</manufacturedProduct>
+							</consumable>
+						</substanceAdministration>
+					</entry>
+					<entry>
+						<encounter classCode="ENC" moodCode="RQO">
+							<code code="185389009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Follow-up visit"/>
+							<effectiveTime>
+								<low value="20000412"/>
+								<high value="20000417"/>
+							</effectiveTime>
+						</encounter>
+					</entry>
+				</section>
+			</component>
+		</structuredBody>
+	</component>
+</ClinicalDocument>

--- a/input/hl7.cda.uv.core.xml
+++ b/input/hl7.cda.uv.core.xml
@@ -150,7 +150,6 @@
 			</reference>
 			<groupingId value="classes"/>
 		</resource>
-		<!--
 		<resource>
 			<extension url="http://hl7.org/fhir/StructureDefinition/implementationguide-resource-format">
 					<valueCode value="application/xml"/>
@@ -162,7 +161,7 @@
 			<description value="Example CDA document"/>
 			<isExample value="true"/>
 			<profile value="http://hl7.org/cda/stds/core/StructureDefinition/ClinicalDocument"/>
-	</resource>-->
+		</resource>
 		<resource>
 			<reference>
 				<reference value="StructureDefinition/CO" />

--- a/input/resources/EIVL-TS.xml
+++ b/input/resources/EIVL-TS.xml
@@ -19,18 +19,18 @@
   <description value="Specifies a periodic interval of time where the recurrence is based on activities of daily living or other important events that are time-related but not fully determined by time."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="http://hl7.org/cda/stds/core/StructureDefinition/EIVL-TS"/>
+  <type value="http://hl7.org/cda/stds/core/StructureDefinition/EIVL_TS"/>
   <baseDefinition value="http://hl7.org/cda/stds/core/StructureDefinition/SXCM-TS"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="EIVL-TS">
-      <path value="EIVL-TS"/>
+    <element id="EIVL_TS">
+      <path value="EIVL_TS"/>
       <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="EIVL-TS.event">
-      <path value="EIVL-TS.event"/>
+    <element id="EIVL_TS.event">
+      <path value="EIVL_TS.event"/>
       <label value="Event"/>
       <definition value="A code for a common (periodical) activity of daily living based on which the event related periodic interval is specified."/>
       <min value="0"/>
@@ -39,8 +39,8 @@
         <code value="http://hl7.org/cda/stds/core/StructureDefinition/CE"/>
       </type>
     </element>
-    <element id="EIVL-TS.offset">
-      <path value="EIVL-TS.offset"/>
+    <element id="EIVL_TS.offset">
+      <path value="EIVL_TS.offset"/>
       <label value="Offset"/>
       <definition value="An interval of elapsed time (duration, not absolute point in time) that marks the offsets for the beginning, width and end of the event-related periodic interval measured from the time each such event actually occurred."/>
       <min value="0"/>

--- a/input/resources/INT-POS.xml
+++ b/input/resources/INT-POS.xml
@@ -19,12 +19,12 @@
   <description value="Positive integer numbers."/>
   <kind value="logical"/>
   <abstract value="true"/>
-  <type value="http://hl7.org/cda/stds/core/StructureDefinition/INT-POS"/>
+  <type value="http://hl7.org/cda/stds/core/StructureDefinition/INT_POS"/>
   <baseDefinition value="http://hl7.org/cda/stds/core/StructureDefinition/INT"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="INT-POS">
-      <path value="INT-POS"/>
+    <element id="INT_POS">
+      <path value="INT_POS"/>
       <min value="1"/>
       <max value="*"/>
     </element>

--- a/input/resources/IVL-INT.xml
+++ b/input/resources/IVL-INT.xml
@@ -13,23 +13,23 @@
   <description value="A set of consecutive values of an ordered base data type."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="http://hl7.org/cda/stds/core/StructureDefinition/IVL-INT"/>
+  <type value="http://hl7.org/cda/stds/core/StructureDefinition/IVL_INT"/>
   <baseDefinition value="http://hl7.org/cda/stds/core/StructureDefinition/ANY"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="IVL-INT">
-      <path value="IVL-INT"/>
+    <element id="IVL_INT">
+      <path value="IVL_INT"/>
       <definition value="Interval of integers"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="IVL-INT.value">
-      <path value="IVL-INT.value"/>
+    <element id="IVL_INT.value">
+      <path value="IVL_INT.value"/>
       <representation value="xmlAttr"/>
       <min value="0"/>
       <max value="1"/>
       <base>
-        <path value="IVL-INT.value"/>
+        <path value="IVL_INT.value"/>
         <min value="0"/>
         <max value="1"/>
       </base>
@@ -38,8 +38,8 @@
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/int-simple"/>
       </type>
     </element>
-    <element id="IVL-INT.low">
-      <path value="IVL-INT.low"/>
+    <element id="IVL_INT.low">
+      <path value="IVL_INT.low"/>
       <label value="Low Boundary"/>
       <definition value="This is the low limit of the interval."/>
       <min value="0"/>
@@ -48,8 +48,8 @@
         <code value="http://hl7.org/cda/stds/core/StructureDefinition/INT"/>
       </type>
     </element>
-    <element id="IVL-INT.high">
-      <path value="IVL-INT.high"/>
+    <element id="IVL_INT.high">
+      <path value="IVL_INT.high"/>
       <label value="High Boundary"/>
       <definition value="This is the high limit of the interval."/>
       <min value="0"/>
@@ -58,8 +58,8 @@
         <code value="http://hl7.org/cda/stds/core/StructureDefinition/INT"/>
       </type>
     </element>
-    <element id="IVL-INT.width">
-      <path value="IVL-INT.width"/>
+    <element id="IVL_INT.width">
+      <path value="IVL_INT.width"/>
       <label value="Width"/>
       <definition value="The difference between high and low boundary. The purpose of distinguishing a width property is to handle all cases of incomplete information symmetrically. In any interval representation only two of the three properties high, low, and width need to be stated and the third can be derived."/>
       <min value="0"/>
@@ -68,8 +68,8 @@
         <code value="http://hl7.org/cda/stds/core/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="IVL-INT.center">
-      <path value="IVL-INT.center"/>
+    <element id="IVL_INT.center">
+      <path value="IVL_INT.center"/>
       <label value="Central Value"/>
       <definition value="The arithmetic mean of the interval (low plus high divided by 2). The purpose of distinguishing the center as a semantic property is for conversions of intervals from and to point values."/>
       <min value="0"/>

--- a/input/resources/IVL-TS.xml
+++ b/input/resources/IVL-TS.xml
@@ -13,17 +13,17 @@
   <description value="A set of consecutive values of an ordered base data type."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="http://hl7.org/cda/stds/core/StructureDefinition/IVL-TS"/>
+  <type value="http://hl7.org/cda/stds/core/StructureDefinition/IVL_TS"/>
   <baseDefinition value="http://hl7.org/cda/stds/core/StructureDefinition/SXCM-TS"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="IVL-TS">
-      <path value="IVL-TS"/>
+    <element id="IVL_TS">
+      <path value="IVL_TS"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="IVL-TS.low">
-      <path value="IVL-TS.low"/>
+    <element id="IVL_TS.low">
+      <path value="IVL_TS.low"/>
       <label value="Low Boundary"/>
       <definition value="This is the low limit of the interval."/>
       <min value="0"/>
@@ -32,8 +32,8 @@
         <code value="http://hl7.org/cda/stds/core/StructureDefinition/TS"/>
       </type>
     </element>
-    <element id="IVL-TS.width">
-      <path value="IVL-TS.width"/>
+    <element id="IVL_TS.width">
+      <path value="IVL_TS.width"/>
       <label value="Width"/>
       <definition value="The difference between high and low boundary. The purpose of distinguishing a width property is to handle all cases of incomplete information symmetrically. In any interval representation only two of the three properties high, low, and width need to be stated and the third can be derived."/>
       <min value="0"/>
@@ -42,8 +42,8 @@
         <code value="http://hl7.org/cda/stds/core/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="IVL-TS.high">
-      <path value="IVL-TS.high"/>
+    <element id="IVL_TS.high">
+      <path value="IVL_TS.high"/>
       <label value="High Boundary"/>
       <definition value="This is the high limit of the interval."/>
       <min value="0"/>
@@ -52,8 +52,8 @@
         <code value="http://hl7.org/cda/stds/core/StructureDefinition/TS"/>
       </type>
     </element>
-    <element id="IVL-TS.center">
-      <path value="IVL-TS.center"/>
+    <element id="IVL_TS.center">
+      <path value="IVL_TS.center"/>
       <label value="Central Value"/>
       <definition value="The arithmetic mean of the interval (low plus high divided by 2). The purpose of distinguishing the center as a semantic property is for conversions of intervals from and to point values."/>
       <min value="0"/>

--- a/input/resources/PIVL-TS.xml
+++ b/input/resources/PIVL-TS.xml
@@ -19,18 +19,18 @@
   <description value="An interval of time that recurs periodically. Periodic intervals have two properties, phase and period. The phase specifies the &quot;interval prototype&quot; that is repeated every period."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="http://hl7.org/cda/stds/core/StructureDefinition/PIVL-TS"/>
+  <type value="http://hl7.org/cda/stds/core/StructureDefinition/PIVL_TS"/>
   <baseDefinition value="http://hl7.org/cda/stds/core/StructureDefinition/SXCM-TS"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="PIVL-TS">
-      <path value="PIVL-TS"/>
+    <element id="PIVL_TS">
+      <path value="PIVL_TS"/>
       <definition value="Note: because this type is defined as an extension of SXCM_T, all of the attributes and elements accepted for T are also accepted by this definition. However, they are NOT allowed by the normative description of this type. Unfortunately, we cannot write a general purpose schematron contraints to provide that extra validation, thus applications must be aware that instance (fragments) that pass validation with this might might still not be legal."/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="PIVL-TS.phase">
-      <path value="PIVL-TS.phase"/>
+    <element id="PIVL_TS.phase">
+      <path value="PIVL_TS.phase"/>
       <label value="Phase"/>
       <definition value="A prototype of the repeating interval, specifying the duration of each occurrence and anchors the periodic interval sequence at a certain point in time."/>
       <min value="0"/>
@@ -39,8 +39,8 @@
         <code value="http://hl7.org/cda/stds/core/StructureDefinition/IVL-TS"/>
       </type>
     </element>
-    <element id="PIVL-TS.period">
-      <path value="PIVL-TS.period"/>
+    <element id="PIVL_TS.period">
+      <path value="PIVL_TS.period"/>
       <label value="Period"/>
       <definition value="A time duration specifying as a reciprocal measure of the frequency at which the periodic interval repeats."/>
       <min value="0"/>
@@ -49,8 +49,8 @@
         <code value="http://hl7.org/cda/stds/core/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="PIVL-TS.alignment">
-      <path value="PIVL-TS.alignment"/>
+    <element id="PIVL_TS.alignment">
+      <path value="PIVL_TS.alignment"/>
       <representation value="xmlAttr"/>
       <label value="Alignment to the Calendar"/>
       <definition value="Specifies if and how the repetitions are aligned to the cycles of the underlying calendar (e.g., to distinguish every 30 days from &quot;the 5th of every month&quot;.) A non-aligned periodic interval recurs independently from the calendar. An aligned periodic interval is synchronized with the calendar."/>
@@ -61,8 +61,8 @@
         <profile value="http://hl7.org/cda/stds/core/StructureDefinition/cs-simple"/>
       </type>
     </element>
-    <element id="PIVL-TS.institutionSpecified">
-      <path value="PIVL-TS.institutionSpecified"/>
+    <element id="PIVL_TS.institutionSpecified">
+      <path value="PIVL_TS.institutionSpecified"/>
       <representation value="xmlAttr"/>
       <label value="Institution Specified Timing"/>
       <definition value="Indicates whether the exact timing is up to the party executing the schedule (e.g., to distinguish &quot;every 8 hours&quot; from &quot;3 times a day&quot;.)"/>

--- a/input/resources/RTO-PQ-PQ.xml
+++ b/input/resources/RTO-PQ-PQ.xml
@@ -13,17 +13,17 @@
   <description value="A quantity constructed as the quotient of a numerator quantity divided by a denominator quantity. Common factors in the numerator and denominator are not automatically cancelled out. The data type supports titers (e.g., &quot;1:128&quot;) and other quantities produced by laboratories that truly represent ratios. Ratios are not simply &quot;structured numerics&quot;, particularly blood pressure measurements (e.g. &quot;120/60&quot;) are not ratios. In many cases the should be used instead of the ."/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="http://hl7.org/cda/stds/core/StructureDefinition/RTO-PQ-PQ"/>
+  <type value="http://hl7.org/cda/stds/core/StructureDefinition/RTO_PQ_PQ"/>
   <baseDefinition value="http://hl7.org/cda/stds/core/StructureDefinition/QTY"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="RTO-PQ-PQ">
-      <path value="RTO-PQ-PQ"/>
+    <element id="RTO_PQ_PQ">
+      <path value="RTO_PQ_PQ"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="RTO-PQ-PQ.numerator">
-      <path value="RTO-PQ-PQ.numerator"/>
+    <element id="RTO_PQ_PQ.numerator">
+      <path value="RTO_PQ_PQ.numerator"/>
       <label value="Numerator"/>
       <definition value="The quantity that is being divided in the ratio. The default is the integer number 1 (one.)"/>
       <min value="0"/>
@@ -32,8 +32,8 @@
         <code value="http://hl7.org/cda/stds/core/StructureDefinition/PQ"/>
       </type>
     </element>
-    <element id="RTO-PQ-PQ.denominator">
-      <path value="RTO-PQ-PQ.denominator"/>
+    <element id="RTO_PQ_PQ.denominator">
+      <path value="RTO_PQ_PQ.denominator"/>
       <label value="Denominator"/>
       <definition value="The quantity that devides the numerator in the ratio. The default is the integer number 1 (one.) The denominator must not be zero."/>
       <min value="0"/>

--- a/input/resources/RelatedDocument.xml
+++ b/input/resources/RelatedDocument.xml
@@ -56,7 +56,7 @@
       
       <binding>
         <strength value="required"/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ParticipationType"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-xActRelationshipDocument"/>
       </binding>
     </element>
     <element id="RelatedDocument.realmCode">

--- a/input/resources/SXCM-TS.xml
+++ b/input/resources/SXCM-TS.xml
@@ -13,17 +13,17 @@
   <description value="A set of points in time, specifying the timing of events and actions and the cyclical validity-patterns that may exist for certain kinds of information, such as phone numbers (evening, daytime), addresses (so called &quot;snowbirds,&quot; residing closer to the equator during winter and farther from the equator during summer) and office hours."/>
   <kind value="logical"/>
   <abstract value="true"/>
-  <type value="http://hl7.org/cda/stds/core/StructureDefinition/SXCM-TS"/>
+  <type value="http://hl7.org/cda/stds/core/StructureDefinition/SXCM_TS"/>
   <baseDefinition value="http://hl7.org/cda/stds/core/StructureDefinition/TS"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="SXCM-TS">
-      <path value="SXCM-TS"/>
+    <element id="SXCM_TS">
+      <path value="SXCM_TS"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="SXCM-TS.operator">
-      <path value="SXCM-TS.operator"/>
+    <element id="SXCM_TS.operator">
+      <path value="SXCM_TS.operator"/>
       <representation value="xmlAttr"/>
       <definition value="A code specifying whether the set component is included (union) or excluded (set-difference) from the set, or other set operations with the current set component and the set as constructed from the representation stream up to the current point."/>
       <min value="0"/>

--- a/input/resources/SXPR-TS.xml
+++ b/input/resources/SXPR-TS.xml
@@ -13,17 +13,17 @@
   <description value="A set-component that is itself made up of set-components that are evaluated as one value"/>
   <kind value="logical"/>
   <abstract value="false"/>
-  <type value="http://hl7.org/cda/stds/core/StructureDefinition/SXPR-TS"/>
+  <type value="http://hl7.org/cda/stds/core/StructureDefinition/SXPR_TS"/>
   <baseDefinition value="http://hl7.org/cda/stds/core/StructureDefinition/SXCM-TS"/>
   <derivation value="specialization"/>
   <differential>
-    <element id="SXPR-TS">
-      <path value="SXPR-TS"/>
+    <element id="SXPR_TS">
+      <path value="SXPR_TS"/>
       <min value="1"/>
       <max value="*"/>
     </element>
-    <element id="SXPR-TS.comp">
-      <path value="SXPR-TS.comp"/>
+    <element id="SXPR_TS.comp">
+      <path value="SXPR_TS.comp"/>
       <representation value="typeAttr"/>
       <min value="1"/>
       <max value="*"/>


### PR DESCRIPTION
Long story short - I changed all the types from IVL_TS to IVL-TS because that seemed to make sushi happy in C-CDA. But the type definitions need to be IVL_TS, because that's what drives "xsi:type" resolution. And we're on the road to fixing Sushi.

So in summary:

- `id` cannot contain _, so these all have id's with -'s: IVL-TS
- `url` must end with id, so the url's all look like `/StructureDefinition/IVL-TS`
- `type` must match xsi:type - so type ends in `/StructureDefinition/IVL_TS`
- `name` throws warning if it contains `-`, plus the real name is `_`, so setting to `IVL_TS`
- element.id / element.path - are based on type, so they all start with `IVL_TS`
- baseDefinition / element.type / element.profile - references and canonicals are all based on url, so they contain look like `/StructureDefinition/IVL-TS`
