### PR TITLE
20240328_SDTC Extension

### DIFF
--- a/schema/extensions/SDTC/infrastructure/cda/POCD_MT000040_SDTC.xsd
+++ b/schema/extensions/SDTC/infrastructure/cda/POCD_MT000040_SDTC.xsd
@@ -95,6 +95,10 @@
                  Person/sdtc:asPatientRelationship
     </xs:documentation>
     <xs:documentation>
+      2015-06-01 Added extension approved by SDWG on 2014-11-06
+                 EncompassingEncounter/sdtc:admissionReferralSourceCode
+    </xs:documentation>
+    <xs:documentation>
           2016-05-12 Added extension approved by SDWG on 2016-01-28
                      Component4/priorityNumber
       </xs:documentation>
@@ -515,6 +519,9 @@
       <xs:element name="id" type="II" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="code" type="CE" minOccurs="0" />
       <xs:element name="effectiveTime" type="IVL_TS" />
+      <!-- Begin Extension: (SDTC) -->
+      <xs:element ref="sdtc:admissionReferralSourceCode" minOccurs="0" />
+      <!-- End Extension: (SDTC) -->
       <xs:element name="dischargeDispositionCode" type="CE" minOccurs="0" />
       <xs:element name="responsibleParty" type="POCD_MT000040.ResponsibleParty" minOccurs="0" />
       <xs:element name="encounterParticipant" type="POCD_MT000040.EncounterParticipant" minOccurs="0" maxOccurs="unbounded" />

--- a/schema/extensions/SDTC/infrastructure/cda/POCD_MT000040_SDTC.xsd
+++ b/schema/extensions/SDTC/infrastructure/cda/POCD_MT000040_SDTC.xsd
@@ -127,6 +127,10 @@
       Added alternateIdentification extension approved by SDWG on 2020-09
       Fix missing sdtc: prefix on functionCode approved by SDWG on 2020-10
     </xs:documentation>
+    <xs:documentation>
+      2024-03-21
+      Added CustodianOrganization/sdtc:telecom extension approved by SDWG on 2020-12
+    </xs:documentation>
 
   </xs:annotation>
   <xs:include schemaLocation="../../processable/coreschemas/datatypes.xsd" />
@@ -470,6 +474,9 @@
       <xs:element name="id" type="II" maxOccurs="unbounded" />
       <xs:element name="name" type="ON" minOccurs="0" />
       <xs:element name="telecom" type="TEL" minOccurs="0" />
+      <!-- Begin Extension: (SDTC) -->
+      <xs:element ref="sdtc:telecom" minOccurs="0" maxOccurs="unbounded" />
+      <!-- End Extension: (SDTC) -->
       <xs:element name="addr" type="AD" minOccurs="0" />
     </xs:sequence>
     <xs:attribute name="nullFlavor" type="NullFlavor" use="optional" />

--- a/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
+++ b/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
@@ -127,6 +127,10 @@
       2020-10-12
       Added alternateIdentification extension approved by SDWG on 2020-09
     </xs:documentation>
+    <xs:documentation>
+      2024-03-21
+      Added telecom extension approved by SDWG on 2020-12
+    </xs:documentation>
   </xs:annotation>
   
   <xs:import namespace="urn:hl7-org:v3" schemaLocation="POCD_MT000040_SDTC.xsd" />
@@ -190,6 +194,7 @@
   <xs:element name="precondition2" type="Precondition2" />
   <xs:element name="text" type="hl7:ED" />
   <xs:element name="identifiedBy" type="IdentifiedBy" />
+  <xs:element name="telecom" type="hl7:TEL" />
   <!-- == End Simple Elements =================================================================== -->
   
   <!-- == Start Complex Elements =================================================================== -->

--- a/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
+++ b/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
@@ -171,7 +171,7 @@
   <!-- == End Attributes =================================================================== -->
     
   <!-- == Start Simple Elements =================================================================== -->
-  <xs:element name="admissionReferralSourceCode" type="hl7:CD" />
+  <xs:element name="admissionReferralSourceCode" type="hl7:CE" />
   <xs:element name="raceCode" type="hl7:CE" />
   <xs:element name="ethnicGroupCode" type="hl7:CE" />
   <xs:element name="dischargeDispositionCode" type="hl7:CE" />

--- a/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
+++ b/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
@@ -93,6 +93,11 @@
       asPatientRelationship
     </xs:documentation>
     <xs:documentation>
+      2015-06-01 
+      Added extension approved by SDWG on 2014-11-06
+      admissionReferralSourceCode
+    </xs:documentation>
+    <xs:documentation>
       2016-05-12 
       Added extension approved by SDWG on 2016-01-28
       priorityNumber
@@ -136,7 +141,6 @@
       <xs:minInclusive value="1" />
     </xs:restriction>
   </xs:simpleType>
-  
   <xs:complexType name="INT_POS">
     <xs:annotation>
       <xs:documentation>Positive integer numbers</xs:documentation>
@@ -155,7 +159,40 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <!-- == End Data Types =================================================================== -->
   
+  <!-- == Start Attributes =================================================================== -->
+  <xs:attribute name="valueSet" type="hl7:oid" />
+  <xs:attribute name="valueSetVersion" type="hl7:st" />
+  <!-- == End Attributes =================================================================== -->
+    
+  <!-- == Start Simple Elements =================================================================== -->
+  <xs:element name="admissionReferralSourceCode" type="hl7:CD" />
+  <xs:element name="raceCode" type="hl7:CE" />
+  <xs:element name="ethnicGroupCode" type="hl7:CE" />
+  <xs:element name="dischargeDispositionCode" type="hl7:CE" />
+  <xs:element name="id" type="hl7:II" />
+  <xs:element name="deceasedInd" type="hl7:BL" />
+  <xs:element name="deceasedTime" type="hl7:TS" />
+  <xs:element name="multipleBirthInd" type="hl7:BL" />
+  <xs:element name="multipleBirthOrderNumber" type="INT_POS" />
+  <xs:element name="birthTime" type="hl7:TS" />
+  <xs:element name="signatureText" type="hl7:ED" />
+  <xs:element name="statusCode" type="hl7:CS" />
+  <xs:element name="desc" type="hl7:ED" />
+  <xs:element name="inFulfillmentOf1" type="InFulfillmentOf1" />
+  <xs:element name="patient" type="SdtcPatient" />
+  <xs:element name="asPatientRelationship" type="AsPatientRelationship" />
+  <xs:element name="priorityNumber" type="hl7:INT" />
+  <xs:element name="functionCode" type="hl7:CE" />
+  <xs:element name="precondition1" type="Precondition1" />
+  <!-- created for Structured Form Definition -->
+  <xs:element name="precondition2" type="Precondition2" />
+  <xs:element name="text" type="hl7:ED" />
+  <xs:element name="identifiedBy" type="IdentifiedBy" />
+  <!-- == End Simple Elements =================================================================== -->
+  
+  <!-- == Start Complex Elements =================================================================== -->
   <!-- ActReference (created for QRDA) -->
   <xs:complexType name="ActReference">
     <xs:sequence>
@@ -168,7 +205,6 @@
     <xs:attribute name="moodCode" type="hl7:x_DocumentActMood" use="required" />
     <xs:attribute name="determinerCode" type="hl7:EntityDeterminer" use="optional" fixed="INSTANCE" />
   </xs:complexType>
-  
   <!-- Fulfills (created for QRDA) -->
   <xs:complexType name="InFulfillmentOf1">
     <xs:sequence>
@@ -181,13 +217,11 @@
     <xs:attribute name="inversionInd" type="hl7:bl" use="optional" />
     <xs:attribute name="negationInd" type="hl7:bl" use="optional" />
   </xs:complexType>
-  
   <xs:complexType name="SdtcPatient">
     <xs:sequence>
       <xs:element name="id" type="hl7:II" minOccurs="1" />
     </xs:sequence>
   </xs:complexType>
-  
   <xs:complexType name="AsPatientRelationship">
     <xs:sequence>
       <xs:element name="realmCode" type="hl7:CS" minOccurs="0" maxOccurs="unbounded" />
@@ -198,7 +232,6 @@
     <xs:attribute name="classCode" type="hl7:x_DocumentSubject" use="required" fixed="PRS" />
     <xs:attribute name="determinerCode" type="hl7:EntityDeterminer" use="optional" fixed="INSTANCE" />
   </xs:complexType>
-  
   <!-- Precondition1 (created for C-CDA Templates for Infectious Disease (lab reporting)) -->
   <xs:complexType name="Precondition1">
     <xs:sequence>
@@ -225,7 +258,6 @@
     <xs:attribute name="typeCode" type="hl7:ActRelationshipType" use="optional" fixed="PRCN" />
     
   </xs:complexType>
-  
   <!-- Precondition2 (created for Structured Form Definition) -->
   <xs:complexType name="Precondition2">
     <xs:sequence>
@@ -250,7 +282,6 @@
     <xs:attribute name="typeCode" type="hl7:ActRelationshipType" use="optional" fixed="PRCN" />
     <xs:attribute name="negationInd" type="xs:boolean" use="optional" fixed="true" />
   </xs:complexType>
-  
   <!-- AllFalse (created for Structured Form Definition) -->
   <xs:complexType name="AllFalse">
     <xs:sequence>
@@ -265,7 +296,6 @@
     <xs:attribute name="classCode" type="hl7:ActClass" use="optional" fixed="CLUSTER" />
     <xs:attribute name="moodCode" type="hl7:ActMood" use="optional" fixed="EVN" />
   </xs:complexType>
-  
   <!-- AllTrue (created for Structured Form Definition) -->
   <xs:complexType name="AllTrue">
     <xs:sequence>
@@ -280,7 +310,6 @@
     <xs:attribute name="classCode" type="hl7:ActClass" use="optional" fixed="CLUSTER" />
     <xs:attribute name="moodCode" type="hl7:ActMood" use="optional" fixed="EVN" />
   </xs:complexType>
-  
   <!-- AtLeastOneFalse (created for Structured Form Definition) -->
   <xs:complexType name="AtLeastOneFalse">
     <xs:sequence>
@@ -295,7 +324,6 @@
     <xs:attribute name="classCode" type="hl7:ActClass" use="optional" fixed="CLUSTER" />
     <xs:attribute name="moodCode" type="hl7:ActMood" use="optional" fixed="EVN" />
   </xs:complexType>
-  
   <!-- AtLeastOneTrue (created for Structured Form Definition) -->
   <xs:complexType name="AtLeastOneTrue">
     <xs:sequence>
@@ -310,7 +338,6 @@
     <xs:attribute name="classCode" type="hl7:ActClass" use="optional" fixed="CLUSTER" />
     <xs:attribute name="moodCode" type="hl7:ActMood" use="optional" fixed="EVN" />
   </xs:complexType>
-  
   <!-- OnlyOneFalse (created for Structured Form Definition) -->
   <xs:complexType name="OnlyOneFalse">
     <xs:sequence>
@@ -325,7 +352,6 @@
     <xs:attribute name="classCode" type="hl7:ActClass" use="optional" fixed="CLUSTER" />
     <xs:attribute name="moodCode" type="hl7:ActMood" use="optional" fixed="EVN" />
   </xs:complexType>
-  
   <!-- OnlyOneTrue (created for Structured Form Definition) -->
   <xs:complexType name="OnlyOneTrue">
     <xs:sequence>
@@ -340,14 +366,12 @@
     <xs:attribute name="classCode" type="hl7:ActClass" use="optional" fixed="CLUSTER" />
     <xs:attribute name="moodCode" type="hl7:ActMood" use="optional" fixed="EVN" />
   </xs:complexType>
-  
   <xs:complexType name="IdentifiedBy">
     <xs:sequence>
       <xs:element name="alternateIdentification" type="AlternateIdentification" minOccurs="1" maxOccurs="1" />
     </xs:sequence>
     <xs:attribute name="typeCode" type="hl7:RoleLinkType" use="required" fixed="REL" />
   </xs:complexType>
-  
   <xs:complexType name="AlternateIdentification">
     <xs:sequence>
       <xs:element name="id" type="hl7:II" minOccurs="1" maxOccurs="1" />
@@ -357,57 +381,5 @@
     </xs:sequence>
     <xs:attribute name="classCode" type="hl7:RoleClass" use="required" fixed="IDENT" />
   </xs:complexType>
-  
-  <!-- == End Data Types =================================================================== -->
-  
-  <!-- == Start Attributes =================================================================== -->
-  <xs:attribute name="valueSet" type="hl7:oid" />
-  <xs:attribute name="valueSetVersion" type="hl7:st" />
-  <!-- == End Attributes =================================================================== -->
-  
-  
-  <!-- == Start Elements =================================================================== -->
-  <xs:element name="raceCode" type="hl7:CE" />
-  <xs:element name="ethnicGroupCode" type="hl7:CE" />
-  
-  <xs:element name="dischargeDispositionCode" type="hl7:CE" />
-  
-  <xs:element name="id" type="hl7:II" />
-  
-  <xs:element name="deceasedInd" type="hl7:BL" />
-  <xs:element name="deceasedTime" type="hl7:TS" />
-  
-  <xs:element name="multipleBirthInd" type="hl7:BL" />
-  <xs:element name="multipleBirthOrderNumber" type="INT_POS" />
-  
-  <xs:element name="birthTime" type="hl7:TS" />
-  
-  <xs:element name="signatureText" type="hl7:ED" />
-  
-  <xs:element name="statusCode" type="hl7:CS" />
-  
-  <xs:element name="desc" type="hl7:ED" />
-  
-  <xs:element name="inFulfillmentOf1" type="InFulfillmentOf1" />
-  
-  <xs:element name="patient" type="SdtcPatient" />
-  
-  <xs:element name="asPatientRelationship" type="AsPatientRelationship" />
-  
-  <xs:element name="priorityNumber" type="hl7:INT" />
-  
-  <xs:element name="functionCode" type="hl7:CE" />
-  
-  <xs:element name="precondition1" type="Precondition1" />
-  
-  <!-- created for Structured Form Definition -->
-  <xs:element name="precondition2" type="Precondition2" />
-  
-  
-  <xs:element name="text" type="hl7:ED" />
-  
-  <xs:element name="identifiedBy" type="IdentifiedBy" />
-  
-  <!-- == End Elements =================================================================== -->
-  
+  <!-- == End Complex Elements =================================================================== -->
 </xs:schema>

--- a/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
+++ b/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
@@ -206,6 +206,7 @@
       <xs:element name="templateId" type="hl7:II" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="id" type="hl7:II" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
+    <xs:attribute name="nullFlavor" type="hl7:NullFlavor" use="optional" />
     <xs:attribute name="classCode" type="hl7:ActClass" use="required" />
     <xs:attribute name="moodCode" type="hl7:x_DocumentActMood" use="required" />
     <xs:attribute name="determinerCode" type="hl7:EntityDeterminer" use="optional" fixed="INSTANCE" />
@@ -218,6 +219,7 @@
       <xs:element name="templateId" type="hl7:II" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="actReference" type="ActReference" />
     </xs:sequence>
+    <xs:attribute name="nullFlavor" type="hl7:NullFlavor" use="optional" />
     <xs:attribute name="typeCode" type="hl7:ActRelationshipFulfills" use="required" fixed="FLFS" />
     <xs:attribute name="inversionInd" type="hl7:bl" use="optional" />
     <xs:attribute name="negationInd" type="hl7:bl" use="optional" />
@@ -234,6 +236,7 @@
       <xs:element name="templateId" type="hl7:II" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="code" type="hl7:CE" />
     </xs:sequence>
+    <xs:attribute name="nullFlavor" type="hl7:NullFlavor" use="optional" />
     <xs:attribute name="classCode" type="hl7:x_DocumentSubject" use="required" fixed="PRS" />
     <xs:attribute name="determinerCode" type="hl7:EntityDeterminer" use="optional" fixed="INSTANCE" />
   </xs:complexType>
@@ -284,6 +287,7 @@
         </xs:choice>
       </xs:choice>
     </xs:sequence>
+    <xs:attribute name="nullFlavor" type="hl7:NullFlavor" use="optional" />
     <xs:attribute name="typeCode" type="hl7:ActRelationshipType" use="optional" fixed="PRCN" />
     <xs:attribute name="negationInd" type="xs:boolean" use="optional" fixed="true" />
   </xs:complexType>

--- a/schema/extensions/SDTC/processable/coreschemas/voc.xsd
+++ b/schema/extensions/SDTC/processable/coreschemas/voc.xsd
@@ -1088,11 +1088,7 @@ RoseTree XML to Schema: $Id: VocabXMLtoXSD.xsl,v 1.6 2005/05/24 00:14:18 lmckenz
       <xs:annotation>
          <xs:documentation>abstDomain: V14900 (C-0-D10317-V10329-V14900-cpt)</xs:documentation>
       </xs:annotation>
-      <xs:union memberTypes="ActRelationshipCostTracking ActRelationshipPosting">
-         <xs:simpleType>
-            <xs:restriction base="cs"/>
-         </xs:simpleType>
-      </xs:union>
+      <xs:union memberTypes="ActRelationshipCostTracking ActRelationshipPosting" />
    </xs:simpleType>
    <xs:simpleType name="ActRelationshipCostTracking">
       <xs:annotation>
@@ -1775,11 +1771,7 @@ RoseTree XML to Schema: $Id: VocabXMLtoXSD.xsl,v 1.6 2005/05/24 00:14:18 lmckenz
       <xs:annotation>
          <xs:documentation>abstDomain: V19313 (C-0-D11555-V13940-V19313-cpt)</xs:documentation>
       </xs:annotation>
-      <xs:union memberTypes="RoleClassMutualRelationship RoleClassPassive">
-         <xs:simpleType>
-            <xs:restriction base="cs"/>
-         </xs:simpleType>
-      </xs:union>
+      <xs:union memberTypes="RoleClassMutualRelationship RoleClassPassive" />
    </xs:simpleType>
    <xs:simpleType name="RoleClassMutualRelationship">
       <xs:annotation>

--- a/schema/normative/processable/coreschemas/voc.xsd
+++ b/schema/normative/processable/coreschemas/voc.xsd
@@ -1088,11 +1088,7 @@ RoseTree XML to Schema: $Id: VocabXMLtoXSD.xsl,v 1.6 2005/05/24 00:14:18 lmckenz
       <xs:annotation>
          <xs:documentation>abstDomain: V14900 (C-0-D10317-V10329-V14900-cpt)</xs:documentation>
       </xs:annotation>
-      <xs:union memberTypes="ActRelationshipCostTracking ActRelationshipPosting">
-         <xs:simpleType>
-            <xs:restriction base="cs"/>
-         </xs:simpleType>
-      </xs:union>
+      <xs:union memberTypes="ActRelationshipCostTracking ActRelationshipPosting" />
    </xs:simpleType>
    <xs:simpleType name="ActRelationshipCostTracking">
       <xs:annotation>
@@ -1775,11 +1771,7 @@ RoseTree XML to Schema: $Id: VocabXMLtoXSD.xsl,v 1.6 2005/05/24 00:14:18 lmckenz
       <xs:annotation>
          <xs:documentation>abstDomain: V19313 (C-0-D11555-V13940-V19313-cpt)</xs:documentation>
       </xs:annotation>
-      <xs:union memberTypes="RoleClassMutualRelationship RoleClassPassive">
-         <xs:simpleType>
-            <xs:restriction base="cs"/>
-         </xs:simpleType>
-      </xs:union>
+      <xs:union memberTypes="RoleClassMutualRelationship RoleClassPassive" />
    </xs:simpleType>
    <xs:simpleType name="RoleClassMutualRelationship">
       <xs:annotation>


### PR DESCRIPTION
Include the following fixes to the CDA extensions schema:

- https://jira.hl7.org/browse/CDA-20040 - Re-add admissionReferralSource to Schema
- https://jira.hl7.org/browse/CDA-20712 - CDA 2.0 Schema poorly defines RoleClassAssociative value set
- https://jira.hl7.org/browse/CDA-20818 - Most SDTC extensions missing nullFlavor
- https://jira.hl7.org/browse/CDA-2089 - Implement sdtc:telecom on custodian

(Note - these are already present in master; this PR is solely for review purposes)