### PR TITLE
Add sdtc:specialty and sdtc:expirationTime

### DIFF
--- a/schema/extensions/SDTC/infrastructure/cda/POCD_MT000040_SDTC.xsd
+++ b/schema/extensions/SDTC/infrastructure/cda/POCD_MT000040_SDTC.xsd
@@ -138,7 +138,9 @@
       Added category extension approved by SDWG on 2024-10
     </xs:documentation>
     <xs:documentation>
-      2025-11-13  Added sdtc:specialty to AssignedAuthor, AssignedEntity, AssociatedEntity, and ParticipantRole
+      2025-11-13  
+      Added sdtc:specialty to AssignedAuthor, AssignedEntity, AssociatedEntity, and ParticipantRole
+      Added sdtc:expirationDate to Material
     </xs:documentation>
 
   </xs:annotation>
@@ -897,6 +899,7 @@
       <xs:element name="code" type="CE" minOccurs="0" />
       <xs:element name="name" type="EN" minOccurs="0" />
       <xs:element name="lotNumberText" type="ST" minOccurs="0" />
+      <xs:element ref="sdtc:expirationTime" minOccurs="0" />
     </xs:sequence>
     <xs:attribute name="nullFlavor" type="NullFlavor" use="optional" />
     <xs:attribute name="classCode" type="EntityClassManufacturedMaterial" use="optional" fixed="MMAT" />

--- a/schema/extensions/SDTC/infrastructure/cda/POCD_MT000040_SDTC.xsd
+++ b/schema/extensions/SDTC/infrastructure/cda/POCD_MT000040_SDTC.xsd
@@ -136,7 +136,10 @@
       Added external*/sdtc:author extension approved by SDWG on 2024-10
       2024-10/25
       Added category extension approved by SDWG on 2024-10
-    </xs:documentation>    
+    </xs:documentation>
+    <xs:documentation>
+      2025-11-13  Added sdtc:specialty to AssignedAuthor, AssignedEntity, AssociatedEntity, and ParticipantRole
+    </xs:documentation>
 
   </xs:annotation>
   <xs:include schemaLocation="../../processable/coreschemas/datatypes.xsd" />
@@ -195,6 +198,7 @@
       <xs:element ref="sdtc:identifiedBy" minOccurs="0" maxOccurs="unbounded" />
       <!-- End Extension: (SDTC) -->
       <xs:element name="code" type="CE" minOccurs="0" />
+      <xs:element ref="sdtc:specialty" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="addr" type="AD" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="telecom" type="TEL" minOccurs="0" maxOccurs="unbounded" />
       <xs:choice>
@@ -226,6 +230,7 @@
       <xs:element ref="sdtc:identifiedBy" minOccurs="0" maxOccurs="unbounded" />
       <!-- End Extension: (SDTC) -->
       <xs:element name="code" type="CE" minOccurs="0" />
+      <xs:element ref="sdtc:specialty" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="addr" type="AD" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="telecom" type="TEL" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="assignedPerson" type="POCD_MT000040.Person" minOccurs="0" />
@@ -247,6 +252,7 @@
       <xs:element ref="sdtc:identifiedBy" minOccurs="0" maxOccurs="unbounded" />
       <!-- End Extension: (SDTC) -->
       <xs:element name="code" type="CE" minOccurs="0" />
+      <xs:element ref="sdtc:specialty" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="addr" type="AD" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="telecom" type="TEL" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="associatedPerson" type="POCD_MT000040.Person" minOccurs="0" />
@@ -1128,6 +1134,7 @@
       <xs:element ref="sdtc:identifiedBy" minOccurs="0" maxOccurs="unbounded" />
       <!-- End Extension: (SDTC) -->
       <xs:element name="code" type="CE" minOccurs="0" />
+      <xs:element ref="sdtc:specialty" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="addr" type="AD" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="telecom" type="TEL" minOccurs="0" maxOccurs="unbounded" />
       <xs:choice>

--- a/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
+++ b/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
@@ -199,6 +199,7 @@
   <xs:element name="identifiedBy" type="IdentifiedBy" />
   <xs:element name="telecom" type="hl7:TEL" />
   <xs:element name="author" type="hl7:POCD_MT000040.Author" />
+  <xs:element name="specialty" type="hl7:CE" />
   <!-- == End Simple Elements =================================================================== -->
   
   <!-- == Start Complex Elements =================================================================== -->

--- a/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
+++ b/schema/extensions/SDTC/infrastructure/cda/SDTC.xsd
@@ -131,6 +131,10 @@
       2024-03-21
       Added telecom extension approved by SDWG on 2020-12
     </xs:documentation>
+    <xs:documentation>
+      2025-11-17
+      Added specialty and expirationTime extensions approved by SDWG for C-CDA R5
+    </xs:documentation>
   </xs:annotation>
   
   <xs:import namespace="urn:hl7-org:v3" schemaLocation="POCD_MT000040_SDTC.xsd" />
@@ -200,6 +204,7 @@
   <xs:element name="telecom" type="hl7:TEL" />
   <xs:element name="author" type="hl7:POCD_MT000040.Author" />
   <xs:element name="specialty" type="hl7:CE" />
+  <xs:element name="expirationTime" type="hl7:IVL_TS" />
   <!-- == End Simple Elements =================================================================== -->
   
   <!-- == Start Complex Elements =================================================================== -->


### PR DESCRIPTION
### https://jira.hl7.org/browse/CDA-21424
Creates a simple CE-type element on 4 fields for specialty. Example usage:

```
<author>
    <time value="20250113"/>
    <assignedAuthor>
        <id root="2.16.840.1.113883.4.6" extension="1234567890"/> <!-- NPI -->
        <code code="207Q00000X"
              codeSystem="2.16.840.1.113883.6.101"
              displayName="Family Medicine"/>
        <sdtc:specialty code="419772000"
                        codeSystem="2.16.840.1.113883.6.96"
                        displayName="Family practice"/>
        <assignedPerson>
            <name>
                <given>John</given>
                <family>Doe</family>
            </name>
        </assignedPerson>
    </assignedAuthor>
</author>

```

### https://jira.hl7.org/browse/CDA-21333
Adds `<expirationTime>` after lotNumberText on Material. DataType is IVL_TS, though the most common usage will be a single timestamp:

```
<manufacturedProduct classCode="MANU">
  <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
  <templateId root="2.16.840.1.113883.10.20.22.4.54" extension="2014-06-09"/>
  <manufacturedMaterial>
    <code code="20" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Infanrix" />
    <lotNumberText nullFlavor="UNK"/>
    <sdtc:expirationTime value="20251231" />
  </manufacturedMaterial>
</manufacturedProduct>
```